### PR TITLE
#6 이메일 인증 시스템 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ out/
 
 ### VS Code ###
 .vscode/
+
+
+### opencode 설정 ###
+AGENTS.md

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,10 @@ dependencies {
 	// DOCKER
 	implementation("org.springframework.boot:spring-boot-docker-compose")
 
+	// Email
+	implementation("org.springframework.boot:spring-boot-starter-mail")
+	implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
+
 }
 
 tasks.withType<Test> {

--- a/src/main/java/com/personal/interview/InterviewApplication.java
+++ b/src/main/java/com/personal/interview/InterviewApplication.java
@@ -2,8 +2,10 @@ package com.personal.interview;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class InterviewApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/personal/interview/domain/auth/controller/EmailVerifyController.java
+++ b/src/main/java/com/personal/interview/domain/auth/controller/EmailVerifyController.java
@@ -2,19 +2,17 @@ package com.personal.interview.domain.auth.controller;
 
 import java.util.UUID;
 
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.ModelAndView;
 
 import com.personal.interview.domain.auth.controller.dto.EmailVerifyResponse;
 import com.personal.interview.domain.auth.service.VerifyService;
 import com.personal.interview.domain.user.entity.UserId;
-import com.personal.interview.global.config.properties.EmailProperties;
 import com.personal.interview.global.exception.DomainException;
 import com.personal.interview.global.security.SecurityUtil;
 
@@ -26,14 +24,13 @@ import lombok.RequiredArgsConstructor;
 public class EmailVerifyController {
 
 	private final VerifyService verifyService;
-	private final EmailProperties emailProperties;
 
 	@PostMapping("/send")
 	public ResponseEntity<EmailVerifyResponse> sendVerificationEmail() {
 		UserId userId = SecurityUtil.getCurrentUserId();
 
 		return ResponseEntity
-			.ok(EmailVerifyResponse.from(verifyService.sendVerifyEmail(userId)));
+				.ok(EmailVerifyResponse.from(verifyService.sendVerifyEmail(userId)));
 	}
 
 	@GetMapping("/verify")
@@ -46,42 +43,34 @@ public class EmailVerifyController {
 		}
 
 		return ResponseEntity
-			.ok(EmailVerifyResponse.from(verifyService.verifyEmail(uuidToken)));
+				.ok(EmailVerifyResponse.from(verifyService.verifyEmail(uuidToken)));
 	}
 
 	/**
-	 * 이메일 인증 링크를 통한 인증 처리 (리다이렉트 방식)
+	 * 이메일 인증 링크를 통한 인증 처리 (뷰 렌더링 방식)
 	 * 
 	 * @param token 인증 토큰
-	 * @return 인증 성공 시 성공 페이지로, 실패 시 실패 페이지로 리다이렉트
+	 * @return 인증 성공 시 성공 페이지, 실패 시 실패 페이지를 직접 렌더링
 	 */
 	@GetMapping("/verify/redirect")
-	public ResponseEntity<Void> verifyEmailWithRedirect(@RequestParam String token) {
+	public ModelAndView verifyEmailWithRedirect(@RequestParam String token) {
 		try {
 			UUID uuidToken = UUID.fromString(token);
 			verifyService.verifyEmail(uuidToken);
 
-			// 인증 성공 시 성공 페이지로 리다이렉트
-			String redirectUrl = emailProperties.baseUrl() + emailProperties.successRedirectPath();
-			return ResponseEntity.status(HttpStatus.FOUND)
-				.header(HttpHeaders.LOCATION, redirectUrl)
-				.build();
-				
+			return new ModelAndView("email/verify-success");
+
 		} catch (DomainException e) {
-			// 비즈니스 예외 발생 시 실패 페이지로 리다이렉트 (에러 코드 포함)
-			String redirectUrl = emailProperties.baseUrl() + emailProperties.failureRedirectPath()
-				+ "?reason=" + e.getErrorCode().getCode();
-			return ResponseEntity.status(HttpStatus.FOUND)
-				.header(HttpHeaders.LOCATION, redirectUrl)
-				.build();
-				
+			ModelAndView mav = new ModelAndView("email/verify-failure");
+			mav.addObject("errorMessage", e.getMessage());
+			mav.addObject("errorCode", e.getErrorCode().getCode());
+			return mav;
+
 		} catch (IllegalArgumentException e) {
-			// 토큰 형식 오류 시 실패 페이지로 리다이렉트
-			String redirectUrl = emailProperties.baseUrl() + emailProperties.failureRedirectPath()
-				+ "?reason=INVALID_TOKEN_FORMAT";
-			return ResponseEntity.status(HttpStatus.FOUND)
-				.header(HttpHeaders.LOCATION, redirectUrl)
-				.build();
+			ModelAndView mav = new ModelAndView("email/verify-failure");
+			mav.addObject("errorMessage", "유효하지 않은 토큰 형식입니다.");
+			mav.addObject("errorCode", "INVALID_TOKEN_FORMAT");
+			return mav;
 		}
 	}
 }

--- a/src/main/java/com/personal/interview/domain/auth/controller/EmailVerifyController.java
+++ b/src/main/java/com/personal/interview/domain/auth/controller/EmailVerifyController.java
@@ -2,6 +2,8 @@ package com.personal.interview.domain.auth.controller;
 
 import java.util.UUID;
 
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -12,6 +14,8 @@ import org.springframework.web.bind.annotation.RestController;
 import com.personal.interview.domain.auth.controller.dto.EmailVerifyResponse;
 import com.personal.interview.domain.auth.service.VerifyService;
 import com.personal.interview.domain.user.entity.UserId;
+import com.personal.interview.global.config.properties.EmailProperties;
+import com.personal.interview.global.exception.DomainException;
 import com.personal.interview.global.security.SecurityUtil;
 
 import lombok.RequiredArgsConstructor;
@@ -22,6 +26,7 @@ import lombok.RequiredArgsConstructor;
 public class EmailVerifyController {
 
 	private final VerifyService verifyService;
+	private final EmailProperties emailProperties;
 
 	@PostMapping("/send")
 	public ResponseEntity<EmailVerifyResponse> sendVerificationEmail() {
@@ -42,5 +47,41 @@ public class EmailVerifyController {
 
 		return ResponseEntity
 			.ok(EmailVerifyResponse.from(verifyService.verifyEmail(uuidToken)));
+	}
+
+	/**
+	 * 이메일 인증 링크를 통한 인증 처리 (리다이렉트 방식)
+	 * 
+	 * @param token 인증 토큰
+	 * @return 인증 성공 시 성공 페이지로, 실패 시 실패 페이지로 리다이렉트
+	 */
+	@GetMapping("/verify/redirect")
+	public ResponseEntity<Void> verifyEmailWithRedirect(@RequestParam String token) {
+		try {
+			UUID uuidToken = UUID.fromString(token);
+			verifyService.verifyEmail(uuidToken);
+
+			// 인증 성공 시 성공 페이지로 리다이렉트
+			String redirectUrl = emailProperties.baseUrl() + emailProperties.successRedirectPath();
+			return ResponseEntity.status(HttpStatus.FOUND)
+				.header(HttpHeaders.LOCATION, redirectUrl)
+				.build();
+				
+		} catch (DomainException e) {
+			// 비즈니스 예외 발생 시 실패 페이지로 리다이렉트 (에러 코드 포함)
+			String redirectUrl = emailProperties.baseUrl() + emailProperties.failureRedirectPath()
+				+ "?reason=" + e.getErrorCode().getCode();
+			return ResponseEntity.status(HttpStatus.FOUND)
+				.header(HttpHeaders.LOCATION, redirectUrl)
+				.build();
+				
+		} catch (IllegalArgumentException e) {
+			// 토큰 형식 오류 시 실패 페이지로 리다이렉트
+			String redirectUrl = emailProperties.baseUrl() + emailProperties.failureRedirectPath()
+				+ "?reason=INVALID_TOKEN_FORMAT";
+			return ResponseEntity.status(HttpStatus.FOUND)
+				.header(HttpHeaders.LOCATION, redirectUrl)
+				.build();
+		}
 	}
 }

--- a/src/main/java/com/personal/interview/domain/auth/service/EmailVerifySender.java
+++ b/src/main/java/com/personal/interview/domain/auth/service/EmailVerifySender.java
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Component;
 
 import com.personal.interview.domain.user.entity.vo.Email;
 
-// TODO: 추후 EmailVerifySender 구현체 작성 필요
 @Component
 public interface EmailVerifySender{
 	/**

--- a/src/main/java/com/personal/interview/domain/auth/service/EmailVerifySenderImpl.java
+++ b/src/main/java/com/personal/interview/domain/auth/service/EmailVerifySenderImpl.java
@@ -1,0 +1,79 @@
+package com.personal.interview.domain.auth.service;
+
+import java.io.UnsupportedEncodingException;
+import java.util.UUID;
+
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+import com.personal.interview.domain.user.entity.vo.Email;
+import com.personal.interview.global.config.properties.AuthProperties;
+import com.personal.interview.global.config.properties.EmailProperties;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EmailVerifySenderImpl implements EmailVerifySender {
+    
+    private final JavaMailSender javaMailSender;
+    private final SpringTemplateEngine templateEngine;
+    private final EmailProperties emailProperties;
+    private final AuthProperties authProperties;
+
+    @Override
+    public void sendVerificationEmail(Email email, UUID token) {
+        try {
+            MimeMessage mimeMessage = setMessage(email, token);
+
+            javaMailSender.send(mimeMessage);
+            
+            log.info("이메일 발송 성공: email={}, token={}", email.value(), token);
+            
+        } catch (Exception e) {
+            log.error("이메일 발송 실패: email={}, token={}, error={}", 
+                email.value(), token, e.getMessage(), e);
+        }
+    }
+
+    private MimeMessage setMessage(Email email, UUID token) throws
+        MessagingException,
+        UnsupportedEncodingException {
+        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, true, "UTF-8");
+
+        helper.setFrom(emailProperties.senderEmail(), emailProperties.senderName());
+
+        helper.setTo(email.value());
+
+        helper.setSubject("[Personal Interview] 이메일 인증을 완료해주세요");
+
+        String htmlContent = generateEmailContent(token);
+        helper.setText(htmlContent, true);
+        return mimeMessage;
+    }
+
+    /**
+     * Thymeleaf 템플릿을 사용하여 HTML 이메일 콘텐츠 생성
+     */
+    private String generateEmailContent(UUID token) {
+        Context context = new Context();
+        
+        // 인증 링크 생성
+        String verificationLink = String.format("%s/api/auth/email/verify/redirect?token=%s",
+            emailProperties.baseUrl(), token);
+        
+        context.setVariable("verificationLink", verificationLink);
+        context.setVariable("expirationMinutes", authProperties.verificationExpirationMinutes());
+        
+        return templateEngine.process("email/verification", context);
+    }
+}

--- a/src/main/java/com/personal/interview/domain/auth/service/EmailVerifySenderImpl.java
+++ b/src/main/java/com/personal/interview/domain/auth/service/EmailVerifySenderImpl.java
@@ -1,8 +1,11 @@
 package com.personal.interview.domain.auth.service;
 
 import java.io.UnsupportedEncodingException;
+import java.time.Duration;
 import java.util.UUID;
 
+import org.springframework.core.retry.RetryPolicy;
+import org.springframework.core.retry.RetryTemplate;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Component;
@@ -23,23 +26,29 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @RequiredArgsConstructor
 public class EmailVerifySenderImpl implements EmailVerifySender {
-    
     private final JavaMailSender javaMailSender;
     private final SpringTemplateEngine templateEngine;
     private final EmailProperties emailProperties;
     private final AuthProperties authProperties;
+
+    private static final RetryTemplate RETRY_TEMPLATE = new RetryTemplate(
+        RetryPolicy.builder()
+            .includes(Exception.class)
+            .maxRetries(4)
+            .delay(Duration.ofMillis(1000)).build());
 
     @Override
     public void sendVerificationEmail(Email email, UUID token) {
         try {
             MimeMessage mimeMessage = setMessage(email, token);
 
-            javaMailSender.send(mimeMessage);
-            
+            RETRY_TEMPLATE.execute(()->{
+                javaMailSender.send(mimeMessage);
+                return null;});
+
             log.info("이메일 발송 성공: email={}, token={}", email.value(), token);
-            
         } catch (Exception e) {
-            log.error("이메일 발송 실패: email={}, token={}, error={}", 
+            log.error("이메일 발송 실패: email={}, token={}, error={}",
                 email.value(), token, e.getMessage(), e);
         }
     }

--- a/src/main/java/com/personal/interview/global/config/SecurityConfig.java
+++ b/src/main/java/com/personal/interview/global/config/SecurityConfig.java
@@ -30,9 +30,9 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/email/verify").permitAll()
+                        .requestMatchers("/api/auth/email/verify/redirect").permitAll()
                         .requestMatchers("/api/user/signup").permitAll()
-                        .anyRequest().authenticated()
-                )
+                        .anyRequest().authenticated())
                 .formLogin(form -> form.disable())
                 .httpBasic(basic -> basic.disable());
 

--- a/src/main/java/com/personal/interview/global/config/properties/EmailProperties.java
+++ b/src/main/java/com/personal/interview/global/config/properties/EmailProperties.java
@@ -1,0 +1,17 @@
+package com.personal.interview.global.config.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+
+/**
+ * 이메일 발송 관련 설정값을 관리하는 Properties 클래스
+ */
+@ConfigurationProperties(prefix = "app.email")
+public record EmailProperties(
+    @DefaultValue("http://localhost:8080") String baseUrl,
+    @DefaultValue("noreply@personal-interview.com") String senderEmail,
+    @DefaultValue("Personal Interview") String senderName,
+    @DefaultValue("/verified/success") String successRedirectPath,
+    @DefaultValue("/verified/failure") String failureRedirectPath
+) {
+}

--- a/src/main/java/com/personal/interview/global/config/properties/EmailProperties.java
+++ b/src/main/java/com/personal/interview/global/config/properties/EmailProperties.java
@@ -8,10 +8,7 @@ import org.springframework.boot.context.properties.bind.DefaultValue;
  */
 @ConfigurationProperties(prefix = "app.email")
 public record EmailProperties(
-    @DefaultValue("http://localhost:8080") String baseUrl,
-    @DefaultValue("noreply@personal-interview.com") String senderEmail,
-    @DefaultValue("Personal Interview") String senderName,
-    @DefaultValue("/verified/success") String successRedirectPath,
-    @DefaultValue("/verified/failure") String failureRedirectPath
-) {
+        @DefaultValue("http://localhost:8080") String baseUrl,
+        @DefaultValue("noreply@personal-interview.com") String senderEmail,
+        @DefaultValue("Personal Interview") String senderName) {
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -36,6 +36,18 @@ spring:
       enabled: true
       file: compose.yaml
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${GMAIL_USERNAME}
+    password: ${GMAIL_APP_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
 # MyBatis Configuration
 mybatis:
   mapper-locations: classpath:mapper/**/*.xml

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -16,3 +16,9 @@ app:
     min-send-count: 0
     verification-expiration-minutes: 10
     count-reset-hours: 24
+  email:
+    base-url: ${EMAIL_BASE_URL:http://localhost:8080}
+    sender-email: ${EMAIL_SENDER:noreply@personal-interview.com}
+    sender-name: Personal Interview
+    success-redirect-path: /verified/success
+    failure-redirect-path: /verified/failure

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -20,5 +20,3 @@ app:
     base-url: ${EMAIL_BASE_URL:http://localhost:8080}
     sender-email: ${EMAIL_SENDER:noreply@personal-interview.com}
     sender-name: Personal Interview
-    success-redirect-path: /verified/success
-    failure-redirect-path: /verified/failure

--- a/src/main/resources/templates/email/verification.html
+++ b/src/main/resources/templates/email/verification.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>이메일 인증</title>
+</head>
+<body style="margin: 0; padding: 0; font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; background-color: #f4f4f4;">
+    <table role="presentation" style="width: 100%; border-collapse: collapse; background-color: #f4f4f4;">
+        <tr>
+            <td align="center" style="padding: 40px 0;">
+                <table role="presentation" style="width: 600px; max-width: 100%; border-collapse: collapse; background-color: #ffffff; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
+                    <!-- Header -->
+                    <tr>
+                        <td style="padding: 40px 40px 20px 40px; text-align: center; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); border-radius: 8px 8px 0 0;">
+                            <h1 style="margin: 0; color: #ffffff; font-size: 28px; font-weight: 600;">Personal Interview</h1>
+                        </td>
+                    </tr>
+                    
+                    <!-- Body -->
+                    <tr>
+                        <td style="padding: 40px;">
+                            <h2 style="margin: 0 0 20px 0; color: #333333; font-size: 24px; font-weight: 600;">이메일 인증</h2>
+                            <p style="margin: 0 0 20px 0; color: #666666; font-size: 16px; line-height: 1.6;">
+                                안녕하세요!<br>
+                                Personal Interview에 가입해 주셔서 감사합니다.
+                            </p>
+                            <p style="margin: 0 0 30px 0; color: #666666; font-size: 16px; line-height: 1.6;">
+                                아래 버튼을 클릭하여 이메일 인증을 완료해주세요.
+                            </p>
+                            
+                            <!-- Button -->
+                            <table role="presentation" style="margin: 0 auto;">
+                                <tr>
+                                    <td style="border-radius: 6px; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);">
+                                        <a th:href="${verificationLink}" 
+                                           style="display: inline-block; padding: 16px 40px; color: #ffffff; text-decoration: none; font-size: 16px; font-weight: 600; border-radius: 6px;">
+                                            이메일 인증하기
+                                        </a>
+                                    </td>
+                                </tr>
+                            </table>
+                            
+                            <p style="margin: 30px 0 0 0; color: #999999; font-size: 14px; line-height: 1.6;">
+                                이 링크는 <strong th:text="${expirationMinutes}">10</strong>분 후 만료됩니다.
+                            </p>
+                            
+                            <!-- Alternative link -->
+                            <div style="margin: 30px 0 0 0; padding: 20px; background-color: #f8f9fa; border-radius: 6px; border-left: 4px solid #667eea;">
+                                <p style="margin: 0 0 10px 0; color: #666666; font-size: 14px; font-weight: 600;">
+                                    버튼이 작동하지 않나요?
+                                </p>
+                                <p style="margin: 0; color: #999999; font-size: 13px; word-break: break-all;">
+                                    아래 링크를 복사하여 브라우저 주소창에 붙여넣으세요:<br>
+                                    <span th:text="${verificationLink}" style="color: #667eea;">링크</span>
+                                </p>
+                            </div>
+                        </td>
+                    </tr>
+                    
+                    <!-- Footer -->
+                    <tr>
+                        <td style="padding: 30px 40px; background-color: #f8f9fa; border-radius: 0 0 8px 8px; text-align: center;">
+                            <p style="margin: 0; color: #999999; font-size: 13px; line-height: 1.6;">
+                                본 이메일은 발신 전용입니다. 문의사항이 있으시면 고객센터를 이용해주세요.
+                            </p>
+                            <p style="margin: 10px 0 0 0; color: #999999; font-size: 13px;">
+                                © 2026 Personal Interview. All rights reserved.
+                            </p>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/src/main/resources/templates/email/verify-failure.html
+++ b/src/main/resources/templates/email/verify-failure.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>이메일 인증 실패</title>
+</head>
+
+<body
+    style="margin: 0; padding: 0; font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; background-color: #f4f4f4;">
+    <table role="presentation" style="width: 100%; border-collapse: collapse; background-color: #f4f4f4;">
+        <tr>
+            <td align="center" style="padding: 40px 0;">
+                <table role="presentation"
+                    style="width: 600px; max-width: 100%; border-collapse: collapse; background-color: #ffffff; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
+                    <!-- Header -->
+                    <tr>
+                        <td
+                            style="padding: 40px 40px 20px 40px; text-align: center; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); border-radius: 8px 8px 0 0;">
+                            <h1 style="margin: 0; color: #ffffff; font-size: 28px; font-weight: 600;">Personal Interview
+                            </h1>
+                        </td>
+                    </tr>
+
+                    <!-- Body -->
+                    <tr>
+                        <td style="padding: 40px; text-align: center;">
+                            <!-- 실패 아이콘 -->
+                            <div style="margin: 0 0 24px 0; font-size: 64px;">❌</div>
+
+                            <h2 style="margin: 0 0 20px 0; color: #333333; font-size: 24px; font-weight: 600;">이메일 인증에
+                                실패했습니다</h2>
+                            <p style="margin: 0 0 20px 0; color: #666666; font-size: 16px; line-height: 1.6;">
+                                이메일 인증을 처리하는 중 문제가 발생했습니다.
+                            </p>
+
+                            <!-- 에러 상세 정보 -->
+                            <div
+                                style="margin: 0 0 30px 0; padding: 20px; background-color: #fff3f3; border-radius: 6px; border-left: 4px solid #e74c3c;">
+                                <p style="margin: 0; color: #666666; font-size: 14px; line-height: 1.6;">
+                                    <strong>사유:</strong> <span th:text="${errorMessage}">알 수 없는 오류</span>
+                                </p>
+                            </div>
+
+                            <p style="margin: 0; color: #999999; font-size: 14px; line-height: 1.6;">
+                                인증 메일을 다시 요청해 주세요.<br>
+                                문제가 계속되면 고객센터로 문의해 주세요.
+                            </p>
+                        </td>
+                    </tr>
+
+                    <!-- Footer -->
+                    <tr>
+                        <td
+                            style="padding: 30px 40px; background-color: #f8f9fa; border-radius: 0 0 8px 8px; text-align: center;">
+                            <p style="margin: 0; color: #999999; font-size: 13px; line-height: 1.6;">
+                                이 페이지를 닫아도 됩니다.
+                            </p>
+                            <p style="margin: 10px 0 0 0; color: #999999; font-size: 13px;">
+                                &copy; 2026 Personal Interview. All rights reserved.
+                            </p>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+
+</html>

--- a/src/main/resources/templates/email/verify-success.html
+++ b/src/main/resources/templates/email/verify-success.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>이메일 인증 완료</title>
+</head>
+<body style="margin: 0; padding: 0; font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; background-color: #f4f4f4;">
+    <table role="presentation" style="width: 100%; border-collapse: collapse; background-color: #f4f4f4;">
+        <tr>
+            <td align="center" style="padding: 40px 0;">
+                <table role="presentation" style="width: 600px; max-width: 100%; border-collapse: collapse; background-color: #ffffff; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
+                    <!-- Header -->
+                    <tr>
+                        <td style="padding: 40px 40px 20px 40px; text-align: center; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); border-radius: 8px 8px 0 0;">
+                            <h1 style="margin: 0; color: #ffffff; font-size: 28px; font-weight: 600;">Personal Interview</h1>
+                        </td>
+                    </tr>
+                    
+                    <!-- Body -->
+                    <tr>
+                        <td style="padding: 40px; text-align: center;">
+                            <!-- 성공 아이콘 -->
+                            <div style="margin: 0 0 24px 0; font-size: 64px;">✅</div>
+                            
+                            <h2 style="margin: 0 0 20px 0; color: #333333; font-size: 24px; font-weight: 600;">이메일 인증이 완료되었습니다</h2>
+                            <p style="margin: 0 0 30px 0; color: #666666; font-size: 16px; line-height: 1.6;">
+                                이메일 인증이 성공적으로 완료되었습니다.<br>
+                                이제 Personal Interview의 모든 기능을 이용하실 수 있습니다.
+                            </p>
+                        </td>
+                    </tr>
+                    
+                    <!-- Footer -->
+                    <tr>
+                        <td style="padding: 30px 40px; background-color: #f8f9fa; border-radius: 0 0 8px 8px; text-align: center;">
+                            <p style="margin: 0; color: #999999; font-size: 13px; line-height: 1.6;">
+                                이 페이지를 닫아도 됩니다.
+                            </p>
+                            <p style="margin: 10px 0 0 0; color: #999999; font-size: 13px;">
+                                &copy; 2026 Personal Interview. All rights reserved.
+                            </p>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/src/test/java/com/personal/interview/domain/auth/controller/EmailVerifyControllerTest.java
+++ b/src/test/java/com/personal/interview/domain/auth/controller/EmailVerifyControllerTest.java
@@ -25,6 +25,10 @@ import com.personal.interview.domain.auth.service.VerifyService;
 import com.personal.interview.domain.user.entity.UserId;
 import com.personal.interview.global.config.SecurityConfig;
 import com.personal.interview.global.config.properties.AuthProperties;
+import com.personal.interview.global.exception.DomainException;
+import com.personal.interview.global.exception.BaseErrorCode;
+
+import org.springframework.http.HttpStatus;
 
 @WebMvcTest(EmailVerifyController.class)
 @Import(SecurityConfig.class)
@@ -35,9 +39,6 @@ class EmailVerifyControllerTest {
 
     @MockitoBean
     private VerifyService verifyService;
-
-    @MockitoBean
-    private com.personal.interview.global.config.properties.EmailProperties emailProperties;
 
     private AuthProperties authProperties;
 
@@ -58,8 +59,8 @@ class EmailVerifyControllerTest {
         // when & then
         mockMvc.perform(post("/api/auth/email/send")
                 .with(csrf()))
-            .andDo(print())
-            .andExpect(status().isOk());
+                .andDo(print())
+                .andExpect(status().isOk());
     }
 
     @Test
@@ -69,15 +70,15 @@ class EmailVerifyControllerTest {
         UUID token = UUID.randomUUID();
         EmailVerify mockVerify = EmailVerify.create(new UserId(1L), authProperties);
         mockVerify.verify();
-        
+
         given(verifyService.verifyEmail(token)).willReturn(mockVerify);
 
         // when & then
         mockMvc.perform(get("/api/auth/email/verify")
                 .param("token", token.toString()))
-            .andDo(print())
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.isVerify").value(true));
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isVerify").value(true));
     }
 
     @Test
@@ -89,7 +90,75 @@ class EmailVerifyControllerTest {
         // when & then
         mockMvc.perform(get("/api/auth/email/verify")
                 .param("token", invalidToken))
-            .andDo(print())
-            .andExpect(status().isBadRequest());
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("이메일 인증 리다이렉트 - 성공 시 성공 페이지 렌더링")
+    void verifyEmailWithRedirect_Success() throws Exception {
+        // given
+        UUID token = UUID.randomUUID();
+        EmailVerify mockVerify = EmailVerify.create(new UserId(1L), authProperties);
+        mockVerify.verify();
+
+        given(verifyService.verifyEmail(token)).willReturn(mockVerify);
+
+        // when & then
+        mockMvc.perform(get("/api/auth/email/verify/redirect")
+                .param("token", token.toString()))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(view().name("email/verify-success"));
+    }
+
+    @Test
+    @DisplayName("이메일 인증 리다이렉트 - 도메인 예외 시 실패 페이지 렌더링")
+    void verifyEmailWithRedirect_DomainException() throws Exception {
+        // given
+        UUID token = UUID.randomUUID();
+
+        given(verifyService.verifyEmail(token))
+                .willThrow(DomainException.create(new BaseErrorCode() {
+                    @Override
+                    public String getCode() {
+                        return "EXPIRED_TOKEN";
+                    }
+
+                    @Override
+                    public String getMessage() {
+                        return "만료된 토큰입니다.";
+                    }
+
+                    @Override
+                    public HttpStatus getStatus() {
+                        return HttpStatus.BAD_REQUEST;
+                    }
+                }));
+
+        // when & then
+        mockMvc.perform(get("/api/auth/email/verify/redirect")
+                .param("token", token.toString()))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(view().name("email/verify-failure"))
+                .andExpect(model().attribute("errorCode", "EXPIRED_TOKEN"))
+                .andExpect(model().attribute("errorMessage", "만료된 토큰입니다."));
+    }
+
+    @Test
+    @DisplayName("이메일 인증 리다이렉트 - 잘못된 토큰 형식 시 실패 페이지 렌더링")
+    void verifyEmailWithRedirect_InvalidTokenFormat() throws Exception {
+        // given
+        String invalidToken = "invalid-token";
+
+        // when & then
+        mockMvc.perform(get("/api/auth/email/verify/redirect")
+                .param("token", invalidToken))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(view().name("email/verify-failure"))
+                .andExpect(model().attribute("errorCode", "INVALID_TOKEN_FORMAT"))
+                .andExpect(model().attribute("errorMessage", "유효하지 않은 토큰 형식입니다."));
     }
 }

--- a/src/test/java/com/personal/interview/domain/auth/controller/EmailVerifyControllerTest.java
+++ b/src/test/java/com/personal/interview/domain/auth/controller/EmailVerifyControllerTest.java
@@ -36,6 +36,9 @@ class EmailVerifyControllerTest {
     @MockitoBean
     private VerifyService verifyService;
 
+    @MockitoBean
+    private com.personal.interview.global.config.properties.EmailProperties emailProperties;
+
     private AuthProperties authProperties;
 
     @BeforeEach
@@ -65,7 +68,7 @@ class EmailVerifyControllerTest {
         // given
         UUID token = UUID.randomUUID();
         EmailVerify mockVerify = EmailVerify.create(new UserId(1L), authProperties);
-        mockVerify.verify(); // 인증 완료 상태로 변경
+        mockVerify.verify();
         
         given(verifyService.verifyEmail(token)).willReturn(mockVerify);
 

--- a/src/test/java/com/personal/interview/domain/auth/service/EmailVerifySenderImplTest.java
+++ b/src/test/java/com/personal/interview/domain/auth/service/EmailVerifySenderImplTest.java
@@ -1,0 +1,123 @@
+package com.personal.interview.domain.auth.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+import com.personal.interview.domain.user.entity.vo.Email;
+import com.personal.interview.global.config.properties.AuthProperties;
+import com.personal.interview.global.config.properties.EmailProperties;
+
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+
+@ExtendWith(MockitoExtension.class)
+class EmailVerifySenderImplTest {
+
+    @Mock
+    private JavaMailSender mailSender;
+
+    @Mock
+    private SpringTemplateEngine templateEngine;
+
+    @Mock
+    private EmailProperties emailProperties;
+
+    @Mock
+    private AuthProperties authProperties;
+
+    @InjectMocks
+    private EmailVerifySenderImpl emailVerifySender;
+
+    private Email testEmail;
+    private UUID testToken;
+    private MimeMessage mockMimeMessage;
+
+    @BeforeEach
+    void setUp() {
+        testEmail = new Email("test@example.com");
+        testToken = UUID.randomUUID();
+        mockMimeMessage = new MimeMessage((Session) null);
+
+        // EmailProperties Mock 설정
+        given(emailProperties.baseUrl()).willReturn("http://localhost:8080");
+        given(emailProperties.senderEmail()).willReturn("noreply@personal-interview.com");
+        given(emailProperties.senderName()).willReturn("Personal Interview");
+
+        // AuthProperties Mock 설정
+        given(authProperties.verificationExpirationMinutes()).willReturn(10);
+
+        // JavaMailSender Mock 설정
+        given(mailSender.createMimeMessage()).willReturn(mockMimeMessage);
+
+        // TemplateEngine Mock 설정
+        given(templateEngine.process(eq("email/verification"), any())).willReturn("<html>Test Email</html>");
+    }
+
+    @Test
+    @DisplayName("이메일 발송 성공")
+    void sendVerificationEmail_Success() {
+        // given
+        doNothing().when(mailSender).send(any(MimeMessage.class));
+
+        // when
+        assertThatCode(() -> emailVerifySender.sendVerificationEmail(testEmail, testToken))
+            .doesNotThrowAnyException();
+
+        // then
+        verify(mailSender, times(1)).createMimeMessage();
+        verify(mailSender, times(1)).send(any(MimeMessage.class));
+        verify(templateEngine, times(1)).process(eq("email/verification"), any());
+    }
+
+    @Test
+    @DisplayName("이메일 발송 실패 시 예외를 로깅하고 계속 진행")
+    void sendVerificationEmail_SendFail_LogsErrorAndContinues() {
+        // given
+        doThrow(new RuntimeException("SMTP connection failed"))
+            .when(mailSender).send(any(MimeMessage.class));
+
+        // when & then
+        // 예외가 throw되지 않고 로깅만 되어야 함
+        assertThatCode(() -> emailVerifySender.sendVerificationEmail(testEmail, testToken))
+            .doesNotThrowAnyException();
+
+        verify(mailSender, times(1)).send(any(MimeMessage.class));
+    }
+
+    @Test
+    @DisplayName("Thymeleaf 템플릿에 올바른 변수가 전달되는지 검증")
+    void sendVerificationEmail_TemplateVariablesCorrect() {
+        // given
+        ArgumentCaptor<org.thymeleaf.context.Context> contextCaptor = 
+            ArgumentCaptor.forClass(org.thymeleaf.context.Context.class);
+
+        // when
+        emailVerifySender.sendVerificationEmail(testEmail, testToken);
+
+        // then
+        verify(templateEngine).process(eq("email/verification"), contextCaptor.capture());
+
+        org.thymeleaf.context.Context capturedContext = contextCaptor.getValue();
+        String verificationLink = (String) capturedContext.getVariable("verificationLink");
+        Integer expirationMinutes = (Integer) capturedContext.getVariable("expirationMinutes");
+
+        assertThat(verificationLink).contains("http://localhost:8080");
+        assertThat(verificationLink).contains("/api/auth/email/verify/redirect");
+        assertThat(verificationLink).contains(testToken.toString());
+        assertThat(expirationMinutes).isEqualTo(10);
+    }
+}

--- a/src/test/java/com/personal/interview/domain/auth/service/EmailVerifySenderImplTest.java
+++ b/src/test/java/com/personal/interview/domain/auth/service/EmailVerifySenderImplTest.java
@@ -83,20 +83,6 @@ class EmailVerifySenderImplTest {
         verify(templateEngine, times(1)).process(eq("email/verification"), any());
     }
 
-    @Test
-    @DisplayName("이메일 발송 실패 시 예외를 로깅하고 계속 진행")
-    void sendVerificationEmail_SendFail_LogsErrorAndContinues() {
-        // given
-        doThrow(new RuntimeException("SMTP connection failed"))
-            .when(mailSender).send(any(MimeMessage.class));
-
-        // when & then
-        // 예외가 throw되지 않고 로깅만 되어야 함
-        assertThatCode(() -> emailVerifySender.sendVerificationEmail(testEmail, testToken))
-            .doesNotThrowAnyException();
-
-        verify(mailSender, times(1)).send(any(MimeMessage.class));
-    }
 
     @Test
     @DisplayName("Thymeleaf 템플릿에 올바른 변수가 전달되는지 검증")
@@ -119,5 +105,42 @@ class EmailVerifySenderImplTest {
         assertThat(verificationLink).contains("/api/auth/email/verify/redirect");
         assertThat(verificationLink).contains(testToken.toString());
         assertThat(expirationMinutes).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("이메일 발송이 실패하면 retry 동작 검증")
+    void retryTest() {
+        // 첫 2번은 예외 발생, 3번째는 정상 실행(doNothing) 설정
+        doThrow(new RuntimeException("Mail Server Down"))
+            .doThrow(new RuntimeException("Connection Timeout"))
+            .doNothing()
+            .when(mailSender).send(any(MimeMessage.class));
+
+        // When
+        emailVerifySender.sendVerificationEmail(testEmail, testToken);
+
+        // Then
+        verify(mailSender, times(3)).send(any(MimeMessage.class));
+    }
+
+
+    @Test
+    @DisplayName("retry 최대 시도 횟수 검증")
+    void retryFailTest() {
+        // 6번 모두 예외 발생 설정
+        doThrow(new RuntimeException("Mail Server Down"))
+            .doThrow(new RuntimeException("Connection Timeout"))
+            .doThrow(new RuntimeException("Connection Timeout"))
+            .doThrow(new RuntimeException("Connection Timeout"))
+            .doThrow(new RuntimeException("Connection Timeout"))
+            .doThrow(new RuntimeException("Connection Timeout"))
+            .when(mailSender).send(any(MimeMessage.class));
+
+        // When
+        assertThatCode(() -> emailVerifySender.sendVerificationEmail(testEmail, testToken))
+            .doesNotThrowAnyException();
+
+        // Then
+        verify(mailSender, times(5)).send(any(MimeMessage.class));
     }
 }


### PR DESCRIPTION
# #6 이메일 인증 시스템 구현

## 🚀 기능 구현 사항

resolves : #6

### 1. 이메일 발송 구현체 작성 (`EmailVerifySenderImpl`)

- 기존에 인터페이스만 존재하던 `EmailVerifySender`의 구현체를 작성했습니다.
- `JavaMailSender`를 이용한 SMTP 이메일 발송 로직을 구현했습니다.
- `MimeMessageHelper`를 통해 HTML 이메일(UTF-8) 발송을 지원합니다.
- 발송 실패 시 예외를 throw하지 않고 로깅 처리하여, 기존 이벤트 기반 비동기 흐름을 유지합니다.

### 2. 이메일 설정 관리 (`EmailProperties`, SMTP 설정)

- 기존 `AuthProperties` 패턴을 따라 `@ConfigurationProperties`로 `EmailProperties` record를 생성했습니다.
  - `baseUrl`, `senderEmail`, `senderName`
- `InterviewApplication`에 `@ConfigurationPropertiesScan` 추가하여 properties 자동 스캔을 활성화했습니다.
- `application-local.yml`에 Gmail SMTP 설정 추가 (민감 정보는 환경변수로 관리)
- `application.yaml`에 `app.email.*` 기본값 설정 추가

### 3. Thymeleaf 이메일 인증 템플릿 

- `templates/email/verification.html` — 인증 메일 본문 템플릿
- `templates/email/verify-success.html` — 인증 성공 결과 페이지
- `templates/email/verify-failure.html` — 인증 실패 결과 페이지 (에러 사유 표시)
- 기존 `verification.html`과 동일한 디자인 톤 (그라데이션 헤더, 인라인 CSS)

### 4. 이메일 인증 결과 페이지 렌더링 API

- `GET /api/auth/email/verify/redirect?token={uuid}` 엔드포인트 추가
- 리다이렉트 방식이 아닌 **`ModelAndView`를 이용한 Thymeleaf 뷰 직접 렌더링** 방식 채택
  - 인증 성공 → `email/verify-success` 뷰 렌더링
  - 비즈니스 예외 → `email/verify-failure` 뷰에 에러 메시지 전달
  - 토큰 형식 오류 → `email/verify-failure` 뷰에 `INVALID_TOKEN_FORMAT` 전달
- `SecurityConfig`에 해당 경로 `permitAll()` 추가 (이메일 링크 클릭 시 인증 없이 접근)
- 기존 JSON 반환 API(`GET /verify`)는 그대로 유지하여 API 호환성을 보장합니다.


## 🧾 review point

- **리다이렉트 vs 뷰 직접 렌더링**: 초기에는 302 리다이렉트로 성공/실패 페이지로 이동하는 방식을 설계했으나, 
  리다이렉트 대상 페이지가 별도로 필요한 문제가 있어 `ModelAndView`로 Thymeleaf 뷰를 직접 렌더링하는 방식으로 변경했습니다.
  프론트엔드가 구현되면 리다이렉트 방식으로 다시 전환할 수 있습니다.



- **기존 제약사항 준수 확인**:
  - `EmailVerify` 엔티티 수정 없음 
  - `VerifyService` 비즈니스 로직 수정 없음
  - 기존 이벤트 기반 비동기 흐름 유지 (`VerifyService → 이벤트 발행 → EmailVerifyEventListener → EmailVerifySender`) 
  - 기존 테스트 코드 호환성 유지
