### PR TITLE
#8 로그인 및 인가(권한 제어) 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ out/
 
 ### opencode 설정 ###
 AGENTS.md
+.plan/**

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ out/
 ### opencode 설정 ###
 AGENTS.md
 .plan/**
+
+### claudecode 설정 ###
+CLAUDE.md
+.claude/**

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,14 @@ dependencies {
 	// Security
 	implementation("org.springframework.boot:spring-boot-starter-security")
 	testImplementation("org.springframework.boot:spring-boot-starter-security-test")
+	
+	// AOP
+	implementation("org.aspectj:aspectjweaver:1.9.22.1")
+
+	// JWT
+	implementation("io.jsonwebtoken:jjwt-api:0.12.6")
+	runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.6")
+	runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.6")
 
 	// DOCKER
 	implementation("org.springframework.boot:spring-boot-docker-compose")

--- a/src/main/java/com/personal/interview/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/personal/interview/domain/auth/controller/AuthController.java
@@ -1,0 +1,32 @@
+package com.personal.interview.domain.auth.controller;
+
+import static com.personal.interview.domain.user.entity.vo.UserRole.*;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.personal.interview.domain.auth.controller.dto.RefreshTokenRequest;
+import com.personal.interview.domain.auth.controller.dto.TokenResponse;
+import com.personal.interview.domain.auth.service.AuthService;
+import com.personal.interview.domain.user.entity.vo.UserRole;
+import com.personal.interview.global.security.annotation.Authorize;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+    private final AuthService authService;
+
+    @PostMapping("/refresh")
+    public ResponseEntity<TokenResponse> refresh(@RequestBody @Valid RefreshTokenRequest request) {
+        TokenResponse response = authService.refresh(request);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/personal/interview/domain/auth/controller/EmailVerifyController.java
+++ b/src/main/java/com/personal/interview/domain/auth/controller/EmailVerifyController.java
@@ -13,8 +13,10 @@ import org.springframework.web.servlet.ModelAndView;
 import com.personal.interview.domain.auth.controller.dto.EmailVerifyResponse;
 import com.personal.interview.domain.auth.service.VerifyService;
 import com.personal.interview.domain.user.entity.UserId;
+import com.personal.interview.domain.user.entity.vo.UserRole;
 import com.personal.interview.global.exception.DomainException;
 import com.personal.interview.global.security.SecurityUtil;
+import com.personal.interview.global.security.annotation.Authorize;
 
 import lombok.RequiredArgsConstructor;
 
@@ -25,6 +27,7 @@ public class EmailVerifyController {
 
 	private final VerifyService verifyService;
 
+	@Authorize(UserRole.ROLE_DRAFT)
 	@PostMapping("/send")
 	public ResponseEntity<EmailVerifyResponse> sendVerificationEmail() {
 		UserId userId = SecurityUtil.getCurrentUserId();

--- a/src/main/java/com/personal/interview/domain/auth/controller/dto/LoginRequest.java
+++ b/src/main/java/com/personal/interview/domain/auth/controller/dto/LoginRequest.java
@@ -1,0 +1,10 @@
+package com.personal.interview.domain.auth.controller.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotEmpty;
+
+public record LoginRequest(
+        @NotEmpty(message = "이메일을 입력해주세요.") @Email(message = "올바른 이메일 형식을 입력해주세요.") String email,
+
+        @NotEmpty(message = "비밀번호를 입력해주세요.") String password) {
+}

--- a/src/main/java/com/personal/interview/domain/auth/controller/dto/RefreshTokenRequest.java
+++ b/src/main/java/com/personal/interview/domain/auth/controller/dto/RefreshTokenRequest.java
@@ -1,0 +1,7 @@
+package com.personal.interview.domain.auth.controller.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+
+public record RefreshTokenRequest(
+        @NotEmpty(message = "리프레시 토큰을 입력해주세요.") String refreshToken) {
+}

--- a/src/main/java/com/personal/interview/domain/auth/controller/dto/TokenResponse.java
+++ b/src/main/java/com/personal/interview/domain/auth/controller/dto/TokenResponse.java
@@ -1,0 +1,6 @@
+package com.personal.interview.domain.auth.controller.dto;
+
+public record TokenResponse(
+        String accessToken,
+        String refreshToken) {
+}

--- a/src/main/java/com/personal/interview/domain/auth/entity/UserRefreshToken.java
+++ b/src/main/java/com/personal/interview/domain/auth/entity/UserRefreshToken.java
@@ -1,0 +1,64 @@
+package com.personal.interview.domain.auth.entity;
+
+import static java.util.Objects.*;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+import com.personal.interview.domain.user.entity.UserId;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "user_refresh_tokens", indexes = {
+        @Index(name = "idx_user_id", columnList = "userId")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserRefreshToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private UserId userId;
+
+    @Column(nullable = false, length = 500)
+    private String refreshToken;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime expiryAt;
+
+    public static UserRefreshToken create(UserId userId, String refreshHashToken, LocalDateTime expiryAt) {
+        var userRefreshToken = new UserRefreshToken();
+
+        userRefreshToken.refreshToken = requireNonNull(refreshHashToken);
+        userRefreshToken.createdAt = LocalDateTime.now();
+        userRefreshToken.userId = userId;
+        userRefreshToken.expiryAt = requireNonNull(expiryAt);
+
+        return userRefreshToken;
+    }
+
+    public void updateRefreshToken(String newRefreshToken, LocalDateTime newExpiryAt) {
+        this.refreshToken = newRefreshToken;
+        this.createdAt = LocalDateTime.now();
+        this.expiryAt = newExpiryAt;
+    }
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(this.expiryAt);
+    }
+}

--- a/src/main/java/com/personal/interview/domain/auth/entity/UserRefreshToken.java
+++ b/src/main/java/com/personal/interview/domain/auth/entity/UserRefreshToken.java
@@ -3,7 +3,6 @@ package com.personal.interview.domain.auth.entity;
 import static java.util.Objects.*;
 
 import java.time.LocalDateTime;
-import java.util.Objects;
 
 import com.personal.interview.domain.user.entity.UserId;
 
@@ -12,15 +11,16 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.Version;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "user_refresh_tokens", indexes = {
-        @Index(name = "idx_user_id", columnList = "userId")
+@Table(name = "user_refresh_tokens", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_user_refresh_token_user_id", columnNames = "userId")
 })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -29,11 +29,14 @@ public class UserRefreshToken {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private UserId userId;
 
     @Column(nullable = false, length = 500)
     private String refreshToken;
+
+    @Column(nullable = false, length = 64)
+    private String salt;
 
     @Column(nullable = false)
     private LocalDateTime createdAt;
@@ -41,10 +44,14 @@ public class UserRefreshToken {
     @Column(nullable = false)
     private LocalDateTime expiryAt;
 
-    public static UserRefreshToken create(UserId userId, String refreshHashToken, LocalDateTime expiryAt) {
+    @Version
+    private Long version;
+
+    public static UserRefreshToken create(UserId userId, String refreshHashToken, String salt, LocalDateTime expiryAt) {
         var userRefreshToken = new UserRefreshToken();
 
         userRefreshToken.refreshToken = requireNonNull(refreshHashToken);
+        userRefreshToken.salt = requireNonNull(salt);
         userRefreshToken.createdAt = LocalDateTime.now();
         userRefreshToken.userId = userId;
         userRefreshToken.expiryAt = requireNonNull(expiryAt);
@@ -52,10 +59,15 @@ public class UserRefreshToken {
         return userRefreshToken;
     }
 
-    public void updateRefreshToken(String newRefreshToken, LocalDateTime newExpiryAt) {
-        this.refreshToken = newRefreshToken;
+    public void rotateToken(String newRefreshToken, String newSalt, LocalDateTime newExpiryAt) {
+        this.refreshToken = requireNonNull(newRefreshToken);
+        this.salt = requireNonNull(newSalt);
+        this.expiryAt = requireNonNull(newExpiryAt);
         this.createdAt = LocalDateTime.now();
-        this.expiryAt = newExpiryAt;
+    }
+
+    public boolean isWithinGracePeriod(long gracePeriodSeconds) {
+        return LocalDateTime.now().isBefore(createdAt.plusSeconds(gracePeriodSeconds));
     }
 
     public boolean isExpired() {

--- a/src/main/java/com/personal/interview/domain/auth/repository/UserRefreshTokenRepository.java
+++ b/src/main/java/com/personal/interview/domain/auth/repository/UserRefreshTokenRepository.java
@@ -3,15 +3,28 @@ package com.personal.interview.domain.auth.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.personal.interview.domain.auth.entity.UserRefreshToken;
 import com.personal.interview.domain.user.entity.UserId;
 
+import jakarta.persistence.LockModeType;
+
 @Repository
 public interface UserRefreshTokenRepository extends JpaRepository<UserRefreshToken, Long> {
 
     Optional<UserRefreshToken> findByUserId(UserId userId);
+
+    /**
+     * 비관적 락을 사용하여 userId로 RefreshToken을 조회합니다.
+     * RTR 동시성 이슈(TOCTOU)를 방지하기 위해 사용됩니다.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT t FROM UserRefreshToken t WHERE t.userId = :userId")
+    Optional<UserRefreshToken> findByUserIdForUpdate(@Param("userId") UserId userId);
 
     void deleteByUserId(UserId userId);
 }

--- a/src/main/java/com/personal/interview/domain/auth/repository/UserRefreshTokenRepository.java
+++ b/src/main/java/com/personal/interview/domain/auth/repository/UserRefreshTokenRepository.java
@@ -1,0 +1,17 @@
+package com.personal.interview.domain.auth.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.personal.interview.domain.auth.entity.UserRefreshToken;
+import com.personal.interview.domain.user.entity.UserId;
+
+@Repository
+public interface UserRefreshTokenRepository extends JpaRepository<UserRefreshToken, Long> {
+
+    Optional<UserRefreshToken> findByUserId(UserId userId);
+
+    void deleteByUserId(UserId userId);
+}

--- a/src/main/java/com/personal/interview/domain/auth/service/AuthService.java
+++ b/src/main/java/com/personal/interview/domain/auth/service/AuthService.java
@@ -1,10 +1,14 @@
 package com.personal.interview.domain.auth.service;
 
+import static com.personal.interview.domain.user.entity.vo.UserRole.*;
+
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.util.HexFormat;
 
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,7 +23,9 @@ import com.personal.interview.global.security.JwtTokenProvider;
 import com.personal.interview.global.security.service.RefreshTokenService;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AuthService {
@@ -27,13 +33,38 @@ public class AuthService {
     private final UserRefreshTokenRepository userRefreshTokenRepository;
     private final RefreshTokenService refreshTokenService;
 
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
     @Transactional
     public TokenResponse refresh(RefreshTokenRequest request) {
         String requestToken = request.refreshToken();
 
         var userId = validateTokenAndGetUserId(requestToken);
 
-        validateStoredToken(userId, requestToken);
+        UserRefreshToken storedToken = userRefreshTokenRepository.findByUserId(userId)
+                .orElseThrow(() -> DomainException.create(ErrorCode.REFRESH_TOKEN_NOT_FOUND));
+
+        String requestTokenHash = hashToken(requestToken, storedToken.getSalt());
+        boolean tokenMatches = storedToken.getRefreshToken().equals(requestTokenHash);
+
+        // 토큰 해시 불일치 → grace period 내이면 동시 요청으로 판단
+        if (!tokenMatches) {
+            if (storedToken.isWithinGracePeriod(jwtTokenProvider.getRefreshGracePeriodSeconds())) {
+                log.info("Grace Period 내 동시 요청 감지 (userId: {}). 회전 없이 새 Access Token만 발급합니다.", userId);
+
+                String accessToken = jwtTokenProvider.createAccessToken(userId.longValue(), extractRole(requestToken));
+
+                return new TokenResponse(accessToken, requestToken);
+            }
+
+            userRefreshTokenRepository.deleteByUserId(userId);
+            throw DomainException.create(ErrorCode.REFRESH_TOKEN_REUSE_DETECTED);
+        }
+
+        if (storedToken.isExpired()) {
+            userRefreshTokenRepository.deleteByUserId(userId);
+            throw DomainException.create(ErrorCode.REFRESH_TOKEN_EXPIRED);
+        }
 
         return rotateAndCreateTokens(userId, requestToken);
     }
@@ -47,60 +78,57 @@ public class AuthService {
         return new UserId(jwtTokenProvider.getUserId(requestToken));
     }
 
-    private void validateStoredToken(UserId userId, String requestToken) {
-        UserRefreshToken storedToken = userRefreshTokenRepository.findByUserId(userId)
-                .orElseThrow(() -> DomainException.create(ErrorCode.REFRESH_TOKEN_NOT_FOUND));
-
-        if (!storedToken.getRefreshToken().equals(hashToken(requestToken))) {
-            userRefreshTokenRepository.deleteByUserId(userId);
-
-            throw DomainException.create(ErrorCode.REFRESH_TOKEN_REUSE_DETECTED);
-        }
-
-        if (storedToken.isExpired()) {
-            userRefreshTokenRepository.deleteByUserId(userId);
-            throw DomainException.create(ErrorCode.REFRESH_TOKEN_EXPIRED);
-        }
-    }
-
     private TokenResponse rotateAndCreateTokens(UserId userId, String requestToken) {
-        String role = jwtTokenProvider.getAuthentication(requestToken)
-                .getAuthorities().stream()
-                .findFirst()
-                .map(Object::toString)
-                .orElse("ROLE_USER");
+        String role = extractRole(requestToken);
 
         String newAccessToken = jwtTokenProvider.createAccessToken(userId.longValue(), role);
         String newRefreshToken = jwtTokenProvider.createRefreshToken(userId.longValue(), role);
 
-        refreshTokenService.rotateRefreshToken(userId, newRefreshToken);
+        try {
+            refreshTokenService.rotateRefreshToken(userId, newRefreshToken);
+        } catch (ObjectOptimisticLockingFailureException e) {
+            log.warn("RTR 낙관적 락 충돌 (userId: {}). Grace Period 내 요청으로 처리합니다.", userId);
+
+            return new TokenResponse(newAccessToken, requestToken);
+        }
 
         return new TokenResponse(newAccessToken, newRefreshToken);
     }
 
-    /**
-     * 만료/위변조 토큰에서 userId를 추출하여 해당 사용자의 모든 세션을 무효화합니다.
-     */
+    private String extractRole(String token) {
+        return jwtTokenProvider.getAuthentication(token)
+                .getAuthorities().stream()
+                .findFirst()
+                .map(Object::toString)
+                .orElse(ROLE_DRAFT.name());
+    }
+
     private void handleSuspiciousToken(String token) {
         try {
             Long userId = jwtTokenProvider.getUserIdFromExpiredToken(token);
 
             userRefreshTokenRepository.deleteByUserId(new UserId(userId));
         } catch (Exception ignored) {
-            // userId 추출 불가능한 완전 손상 토큰은 무시
         }
     }
 
-    /**
-     * Refresh Token을 SHA-256으로 해싱합니다.
-     */
-    public static String hashToken(String token) {
+    public static String hashToken(String token, String salt) {
         try {
             MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            byte[] hash = digest.digest(token.getBytes(StandardCharsets.UTF_8));
+
+            byte[] hash = digest.digest((salt + token).getBytes(StandardCharsets.UTF_8));
+
             return HexFormat.of().formatHex(hash);
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException("SHA-256 알고리즘을 찾을 수 없습니다.", e);
         }
+    }
+
+    public static String generateSalt() {
+        byte[] salt = new byte[16];
+
+        SECURE_RANDOM.nextBytes(salt);
+
+        return HexFormat.of().formatHex(salt);
     }
 }

--- a/src/main/java/com/personal/interview/domain/auth/service/AuthService.java
+++ b/src/main/java/com/personal/interview/domain/auth/service/AuthService.java
@@ -1,0 +1,106 @@
+package com.personal.interview.domain.auth.service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.personal.interview.domain.auth.controller.dto.RefreshTokenRequest;
+import com.personal.interview.domain.auth.controller.dto.TokenResponse;
+import com.personal.interview.domain.auth.entity.UserRefreshToken;
+import com.personal.interview.domain.auth.repository.UserRefreshTokenRepository;
+import com.personal.interview.domain.user.entity.UserId;
+import com.personal.interview.global.exception.DomainException;
+import com.personal.interview.global.exception.ErrorCode;
+import com.personal.interview.global.security.JwtTokenProvider;
+import com.personal.interview.global.security.service.RefreshTokenService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserRefreshTokenRepository userRefreshTokenRepository;
+    private final RefreshTokenService refreshTokenService;
+
+    @Transactional
+    public TokenResponse refresh(RefreshTokenRequest request) {
+        String requestToken = request.refreshToken();
+
+        var userId = validateTokenAndGetUserId(requestToken);
+
+        validateStoredToken(userId, requestToken);
+
+        return rotateAndCreateTokens(userId, requestToken);
+    }
+
+    private UserId validateTokenAndGetUserId(String requestToken) {
+        if (!jwtTokenProvider.validateToken(requestToken)) {
+            handleSuspiciousToken(requestToken);
+
+            throw DomainException.create(ErrorCode.REFRESH_TOKEN_REUSE_DETECTED);
+        }
+        return new UserId(jwtTokenProvider.getUserId(requestToken));
+    }
+
+    private void validateStoredToken(UserId userId, String requestToken) {
+        UserRefreshToken storedToken = userRefreshTokenRepository.findByUserId(userId)
+                .orElseThrow(() -> DomainException.create(ErrorCode.REFRESH_TOKEN_NOT_FOUND));
+
+        if (!storedToken.getRefreshToken().equals(hashToken(requestToken))) {
+            userRefreshTokenRepository.deleteByUserId(userId);
+
+            throw DomainException.create(ErrorCode.REFRESH_TOKEN_REUSE_DETECTED);
+        }
+
+        if (storedToken.isExpired()) {
+            userRefreshTokenRepository.deleteByUserId(userId);
+            throw DomainException.create(ErrorCode.REFRESH_TOKEN_EXPIRED);
+        }
+    }
+
+    private TokenResponse rotateAndCreateTokens(UserId userId, String requestToken) {
+        String role = jwtTokenProvider.getAuthentication(requestToken)
+                .getAuthorities().stream()
+                .findFirst()
+                .map(Object::toString)
+                .orElse("ROLE_USER");
+
+        String newAccessToken = jwtTokenProvider.createAccessToken(userId.longValue(), role);
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(userId.longValue(), role);
+
+        refreshTokenService.rotateRefreshToken(userId, newRefreshToken);
+
+        return new TokenResponse(newAccessToken, newRefreshToken);
+    }
+
+    /**
+     * 만료/위변조 토큰에서 userId를 추출하여 해당 사용자의 모든 세션을 무효화합니다.
+     */
+    private void handleSuspiciousToken(String token) {
+        try {
+            Long userId = jwtTokenProvider.getUserIdFromExpiredToken(token);
+
+            userRefreshTokenRepository.deleteByUserId(new UserId(userId));
+        } catch (Exception ignored) {
+            // userId 추출 불가능한 완전 손상 토큰은 무시
+        }
+    }
+
+    /**
+     * Refresh Token을 SHA-256으로 해싱합니다.
+     */
+    public static String hashToken(String token) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(token.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA-256 알고리즘을 찾을 수 없습니다.", e);
+        }
+    }
+}

--- a/src/main/java/com/personal/interview/global/config/SecurityConfig.java
+++ b/src/main/java/com/personal/interview/global/config/SecurityConfig.java
@@ -3,21 +3,50 @@ package com.personal.interview.global.config;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 import com.personal.interview.global.config.properties.AuthProperties;
+import com.personal.interview.global.config.properties.JwtProperties;
+import com.personal.interview.global.security.JwtAuthenticationFilter;
+import com.personal.interview.global.security.JwtTokenProvider;
+import com.personal.interview.global.security.filter.CustomAuthenticationFilter;
+import com.personal.interview.global.security.handler.JwtAccessDeniedHandler;
+import com.personal.interview.global.security.handler.JwtAuthenticationEntryPoint;
+import com.personal.interview.global.security.handler.JwtAuthenticationFailureHandler;
+import com.personal.interview.global.security.handler.JwtAuthenticationSuccessHandler;
+import com.personal.interview.global.security.service.RefreshTokenService;
+import com.personal.interview.util.validator.SecurityValidatorUtil;
+
+import lombok.RequiredArgsConstructor;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Spring Security 설정
  */
 @Configuration
 @EnableWebSecurity
-@EnableConfigurationProperties(AuthProperties.class)
+@EnableMethodSecurity
+@EnableAspectJAutoProxy
+@RequiredArgsConstructor
+@EnableConfigurationProperties({ AuthProperties.class, JwtProperties.class })
 public class SecurityConfig {
+    private final JwtTokenProvider jwtTokenProvider;
+    private final ObjectMapper objectMapper;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    private final SecurityValidatorUtil securityValidatorUtil;
+    private final RefreshTokenService refreshTokenService;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -25,16 +54,48 @@ public class SecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authConfig) throws Exception {
+        return authConfig.getAuthenticationManager();
+    }
+
+    @Bean
+    public CustomAuthenticationFilter customAuthenticationFilter(AuthenticationManager authenticationManager) {
+        CustomAuthenticationFilter filter = new CustomAuthenticationFilter(authenticationManager, objectMapper,
+                securityValidatorUtil);
+        filter.setAuthenticationSuccessHandler(
+                new JwtAuthenticationSuccessHandler(jwtTokenProvider, objectMapper, refreshTokenService));
+        filter.setAuthenticationFailureHandler(
+                new JwtAuthenticationFailureHandler(objectMapper));
+        return filter;
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() {
+        return new JwtAuthenticationFilter(jwtTokenProvider);
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http,
+            CustomAuthenticationFilter customAuthenticationFilter,
+            JwtAuthenticationFilter jwtAuthenticationFilter) throws Exception {
+
         http
-                .csrf(csrf -> csrf.disable())
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                        .accessDeniedHandler(jwtAccessDeniedHandler))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/auth/login").permitAll()
+                        .requestMatchers("/api/auth/refresh").permitAll()
                         .requestMatchers("/api/auth/email/verify").permitAll()
                         .requestMatchers("/api/auth/email/verify/redirect").permitAll()
                         .requestMatchers("/api/user/signup").permitAll()
                         .anyRequest().authenticated())
-                .formLogin(form -> form.disable())
-                .httpBasic(basic -> basic.disable());
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(customAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/personal/interview/global/config/properties/JwtProperties.java
+++ b/src/main/java/com/personal/interview/global/config/properties/JwtProperties.java
@@ -1,0 +1,10 @@
+package com.personal.interview.global.config.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.jwt")
+public record JwtProperties(
+        String secretKey,
+        long accessExpirationMs,
+        long refreshExpirationMs) {
+}

--- a/src/main/java/com/personal/interview/global/config/properties/JwtProperties.java
+++ b/src/main/java/com/personal/interview/global/config/properties/JwtProperties.java
@@ -4,7 +4,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "app.jwt")
 public record JwtProperties(
-        String secretKey,
-        long accessExpirationMs,
-        long refreshExpirationMs) {
+                String secretKey,
+                long accessExpirationMs,
+                long refreshExpirationMs,
+                long refreshGracePeriodSeconds) {
 }

--- a/src/main/java/com/personal/interview/global/exception/ErrorCode.java
+++ b/src/main/java/com/personal/interview/global/exception/ErrorCode.java
@@ -8,16 +8,22 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode implements BaseErrorCode {
-    
+
     // Auth
     ALREADY_VERIFIED(HttpStatus.BAD_REQUEST, "AUTH_001", "이미 인증된 사용자이므로 재전송을 요청할 수 없습니다."),
     EXCEED_MAX_SEND_COUNT(HttpStatus.BAD_REQUEST, "AUTH_002", "일일 인증 횟수를 초과했습니다."),
     VERIFICATION_EXPIRED(HttpStatus.BAD_REQUEST, "AUTH_003", "인증 시간이 만료되었습니다."),
-    INVALID_TOKEN(HttpStatus.BAD_REQUEST, "AUTH_004", "유효하지 않은 인증 토큰입니다."),
-    
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_004", "유효하지 않은 인증 토큰입니다."),
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "AUTH_005", "이메일 또는 비밀번호가 올바르지 않습니다."),
+    REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH_006", "만료된 리프레시 토큰입니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH_007", "존재하지 않는 리프레시 토큰입니다."),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "AUTH_008", "접근 권한이 없습니다."),
+    REFRESH_TOKEN_REUSE_DETECTED(HttpStatus.UNAUTHORIZED, "AUTH_009", "토큰 재사용이 감지되어 모든 세션이 종료되었습니다. 다시 로그인해 주세요."),
+
     // User
     ALREADY_ROLE_USER(HttpStatus.CONFLICT, "USER_001", "이미 해당 권한을 가진 사용자입니다."),
-    DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "USER_002", "이미 사용 중인 이메일입니다.");
+    DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "USER_002", "이미 사용 중인 이메일입니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_003", "존재하지 않는 사용자입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/personal/interview/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/personal/interview/global/exception/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.security.access.AccessDeniedException;
 
 import com.personal.interview.domain.base.VoException;
 
@@ -27,10 +28,10 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(DomainException.class)
     public ResponseEntity<ErrorResponse> handleDomainException(DomainException ex) {
         ErrorResponse response = ErrorResponse.builder()
-            .status(ex.getErrorCode().getStatus().value())
-            .code(ex.getErrorCode().getCode())
-            .message(ex.getMessage())
-            .build();
+                .status(ex.getErrorCode().getStatus().value())
+                .code(ex.getErrorCode().getCode())
+                .message(ex.getMessage())
+                .build();
 
         return new ResponseEntity<>(response, ex.getErrorCode().getStatus());
     }
@@ -41,10 +42,10 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(VoException.class)
     public ResponseEntity<ErrorResponse> handleVoException(VoException ex) {
         ErrorResponse response = ErrorResponse.builder()
-            .status(HttpStatus.INTERNAL_SERVER_ERROR.value())
-            .code(ex.getCode())
-            .message(ex.getMessage())
-            .build();
+                .status(HttpStatus.INTERNAL_SERVER_ERROR.value())
+                .code(ex.getCode())
+                .message(ex.getMessage())
+                .build();
 
         return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
     }
@@ -80,10 +81,10 @@ public class GlobalExceptionHandler {
         }
 
         ErrorResponse response = ErrorResponse.builder()
-            .status(HttpStatus.BAD_REQUEST.value())
-            .code("INVALID_INPUT_VALUE")
-            .message(message)
-            .build();
+                .status(HttpStatus.BAD_REQUEST.value())
+                .code("INVALID_INPUT_VALUE")
+                .message(message)
+                .build();
 
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
@@ -91,10 +92,10 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException ex) {
         ErrorResponse response = ErrorResponse.builder()
-            .status(HttpStatus.BAD_REQUEST.value())
-            .code("INVALID_INPUT")
-            .message(ex.getMessage())
-            .build();
+                .status(HttpStatus.BAD_REQUEST.value())
+                .code("INVALID_INPUT")
+                .message(ex.getMessage())
+                .build();
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 

--- a/src/main/java/com/personal/interview/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/personal/interview/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,46 @@
+package com.personal.interview.global.security;
+
+import java.io.IOException;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+        String token = resolveToken(request);
+
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(BEARER_PREFIX.length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/personal/interview/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/personal/interview/global/security/JwtTokenProvider.java
@@ -1,5 +1,7 @@
 package com.personal.interview.global.security;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.Date;
 
@@ -11,6 +13,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
 
 import com.personal.interview.global.config.properties.JwtProperties;
+import com.personal.interview.global.security.dto.TokenWithExpiry;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -20,15 +23,16 @@ import io.jsonwebtoken.security.Keys;
 
 @Component
 public class JwtTokenProvider {
-
     private final SecretKey secretKey;
     private final long accessExpirationMs;
     private final long refreshExpirationMs;
+    private final long refreshGracePeriodSeconds;
 
     public JwtTokenProvider(JwtProperties jwtProperties) {
         this.secretKey = Keys.hmacShaKeyFor(jwtProperties.secretKey().getBytes());
         this.accessExpirationMs = jwtProperties.accessExpirationMs();
         this.refreshExpirationMs = jwtProperties.refreshExpirationMs();
+        this.refreshGracePeriodSeconds = jwtProperties.refreshGracePeriodSeconds();
     }
 
     public String createAccessToken(Long userId, String role) {
@@ -39,8 +43,24 @@ public class JwtTokenProvider {
         return createToken(userId, role, refreshExpirationMs);
     }
 
+    /**
+     * Refresh Token과 만료시간을 함께 반환합니다.
+     * 토큰 생성 시점의 만료시간을 단일 진실 소스(Single Version of Truth)로 제공합니다.
+     */
+    public TokenWithExpiry createRefreshTokenWithExpiry(Long userId, String role) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + refreshExpirationMs);
+        String token = buildToken(userId, role, now, expiry);
+        LocalDateTime expiresAt = LocalDateTime.ofInstant(expiry.toInstant(), ZoneId.systemDefault());
+        return new TokenWithExpiry(token, expiresAt);
+    }
+
     public long getRefreshExpirationMs() {
         return refreshExpirationMs;
+    }
+
+    public long getRefreshGracePeriodSeconds() {
+        return refreshGracePeriodSeconds;
     }
 
     public Authentication getAuthentication(String token) {
@@ -83,11 +103,14 @@ public class JwtTokenProvider {
     private String createToken(Long userId, String role, long expirationMs) {
         Date now = new Date();
         Date expiry = new Date(now.getTime() + expirationMs);
+        return buildToken(userId, role, now, expiry);
+    }
 
+    private String buildToken(Long userId, String role, Date issuedAt, Date expiry) {
         return Jwts.builder()
                 .subject(String.valueOf(userId))
                 .claim("role", role)
-                .issuedAt(now)
+                .issuedAt(issuedAt)
                 .expiration(expiry)
                 .signWith(secretKey)
                 .compact();

--- a/src/main/java/com/personal/interview/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/personal/interview/global/security/JwtTokenProvider.java
@@ -1,0 +1,103 @@
+package com.personal.interview.global.security;
+
+import java.util.Collections;
+import java.util.Date;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import com.personal.interview.global.config.properties.JwtProperties;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+
+@Component
+public class JwtTokenProvider {
+
+    private final SecretKey secretKey;
+    private final long accessExpirationMs;
+    private final long refreshExpirationMs;
+
+    public JwtTokenProvider(JwtProperties jwtProperties) {
+        this.secretKey = Keys.hmacShaKeyFor(jwtProperties.secretKey().getBytes());
+        this.accessExpirationMs = jwtProperties.accessExpirationMs();
+        this.refreshExpirationMs = jwtProperties.refreshExpirationMs();
+    }
+
+    public String createAccessToken(Long userId, String role) {
+        return createToken(userId, role, accessExpirationMs);
+    }
+
+    public String createRefreshToken(Long userId, String role) {
+        return createToken(userId, role, refreshExpirationMs);
+    }
+
+    public long getRefreshExpirationMs() {
+        return refreshExpirationMs;
+    }
+
+    public Authentication getAuthentication(String token) {
+        Claims claims = parseClaims(token);
+        String userId = claims.getSubject();
+        String role = claims.get("role", String.class);
+
+        return new UsernamePasswordAuthenticationToken(
+                userId,
+                null,
+                Collections.singletonList(new SimpleGrantedAuthority(role)));
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            parseClaims(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    public Long getUserId(String token) {
+        Claims claims = parseClaims(token);
+        return Long.parseLong(claims.getSubject());
+    }
+
+    /**
+     * 만료된 토큰에서도 userId를 추출합니다.
+     * RTR 탈취 감지 시, 만료된 Refresh Token에서 userId를 추출하여 해당 사용자의 모든 세션을 무효화하기 위해 사용됩니다.
+     */
+    public Long getUserIdFromExpiredToken(String token) {
+        try {
+            return getUserId(token);
+        } catch (ExpiredJwtException e) {
+            return Long.parseLong(e.getClaims().getSubject());
+        }
+    }
+
+    private String createToken(Long userId, String role, long expirationMs) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + expirationMs);
+
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .claim("role", role)
+                .issuedAt(now)
+                .expiration(expiry)
+                .signWith(secretKey)
+                .compact();
+    }
+
+    private Claims parseClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/src/main/java/com/personal/interview/global/security/annotation/Authorize.java
+++ b/src/main/java/com/personal/interview/global/security/annotation/Authorize.java
@@ -1,0 +1,22 @@
+package com.personal.interview.global.security.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.personal.interview.domain.user.entity.vo.UserRole;
+
+/**
+ * Controller 메서드나 클래스에 선언하여 지정된 UserRole 만 접근할 수 있도록 인가 검증을 수행하는 어노테이션
+ */
+@Target({ ElementType.METHOD, ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface Authorize {
+    /**
+     * 허용할 권한 목록
+     */
+    UserRole[] value();
+}

--- a/src/main/java/com/personal/interview/global/security/aop/AuthorizeAspect.java
+++ b/src/main/java/com/personal/interview/global/security/aop/AuthorizeAspect.java
@@ -5,7 +5,7 @@ import java.util.Arrays;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
-import org.springframework.security.access.AccessDeniedException;
+import org.aspectj.lang.reflect.MethodSignature;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -22,8 +22,11 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 public class AuthorizeAspect {
 
-    @Before("@annotation(authorize)")
-    public void checkAuthorize(JoinPoint joinPoint, Authorize authorize) {
+    @Before("@annotation(com.personal.interview.global.security.annotation.Authorize) " +
+            "|| @within(com.personal.interview.global.security.annotation.Authorize)")
+    public void checkAuthorize(JoinPoint joinPoint) {
+        Authorize authorize = resolveAuthorize(joinPoint);
+
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         if (authentication == null || !authentication.isAuthenticated()) {
@@ -45,5 +48,22 @@ public class AuthorizeAspect {
                     Arrays.toString(requiredRoles), authentication.getAuthorities());
             throw DomainException.create(ErrorCode.ACCESS_DENIED);
         }
+    }
+
+    /**
+     * 메서드 레벨 → 클래스 레벨 순서로 @Authorize 어노테이션을 탐색합니다.
+     * 메서드에 직접 붙어 있으면 우선 적용하고, 없으면 클래스 레벨을 사용합니다.
+     */
+    private Authorize resolveAuthorize(JoinPoint joinPoint) {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+
+        // 1. 메서드 레벨 어노테이션 확인
+        Authorize methodAnnotation = signature.getMethod().getAnnotation(Authorize.class);
+        if (methodAnnotation != null) {
+            return methodAnnotation;
+        }
+
+        // 2. 클래스 레벨 어노테이션 확인
+        return joinPoint.getTarget().getClass().getAnnotation(Authorize.class);
     }
 }

--- a/src/main/java/com/personal/interview/global/security/aop/AuthorizeAspect.java
+++ b/src/main/java/com/personal/interview/global/security/aop/AuthorizeAspect.java
@@ -1,0 +1,49 @@
+package com.personal.interview.global.security.aop;
+
+import java.util.Arrays;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import com.personal.interview.domain.user.entity.vo.UserRole;
+import com.personal.interview.global.exception.DomainException;
+import com.personal.interview.global.exception.ErrorCode;
+import com.personal.interview.global.security.annotation.Authorize;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Aspect
+@Component
+public class AuthorizeAspect {
+
+    @Before("@annotation(authorize)")
+    public void checkAuthorize(JoinPoint joinPoint, Authorize authorize) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw DomainException.create(ErrorCode.ACCESS_DENIED);
+        }
+
+        UserRole[] requiredRoles = authorize.value();
+        if (requiredRoles.length == 0) {
+            return;
+        }
+
+        boolean hasRole = Arrays.stream(requiredRoles)
+                .map(Enum::name)
+                .anyMatch(role -> authentication.getAuthorities().stream()
+                        .anyMatch(auth -> auth.getAuthority().equals(role)));
+
+        if (!hasRole) {
+            log.warn("권한이 부족합니다. (요구 권한: {}, 현재 사용자 권한: {})",
+                    Arrays.toString(requiredRoles), authentication.getAuthorities());
+            throw DomainException.create(ErrorCode.ACCESS_DENIED);
+        }
+    }
+}

--- a/src/main/java/com/personal/interview/global/security/dto/TokenWithExpiry.java
+++ b/src/main/java/com/personal/interview/global/security/dto/TokenWithExpiry.java
@@ -1,0 +1,10 @@
+package com.personal.interview.global.security.dto;
+
+import java.time.LocalDateTime;
+
+/**
+ * JWT 토큰과 만료시간을 함께 전달하기 위한 DTO입니다.
+ * 토큰 생성 시점의 만료시간을 단일 진실 소스(Single Version of Truth)로 사용합니다.
+ */
+public record TokenWithExpiry(String token, LocalDateTime expiresAt) {
+}

--- a/src/main/java/com/personal/interview/global/security/filter/CustomAuthenticationFilter.java
+++ b/src/main/java/com/personal/interview/global/security/filter/CustomAuthenticationFilter.java
@@ -1,0 +1,45 @@
+package com.personal.interview.global.security.filter;
+
+import java.io.IOException;
+
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
+
+import com.personal.interview.domain.auth.controller.dto.LoginRequest;
+import com.personal.interview.util.validator.SecurityValidatorUtil;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import tools.jackson.databind.ObjectMapper;
+
+public class CustomAuthenticationFilter extends AbstractAuthenticationProcessingFilter {
+    private final ObjectMapper objectMapper;
+    private final SecurityValidatorUtil securityValidatorUtil;
+
+    public CustomAuthenticationFilter(AuthenticationManager authenticationManager, ObjectMapper objectMapper,
+        SecurityValidatorUtil securityValidatorUtil) {
+        super(PathPatternRequestMatcher.withDefaults().matcher(org.springframework.http.HttpMethod.POST,
+                "/api/auth/login"), authenticationManager);
+        this.objectMapper = objectMapper;
+        this.securityValidatorUtil = securityValidatorUtil;
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response)
+            throws AuthenticationException, IOException {
+
+        LoginRequest loginRequest = objectMapper.readValue(request.getInputStream(), LoginRequest.class);
+
+        // dto validation
+        securityValidatorUtil.validate(loginRequest, response);
+
+        UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(loginRequest.email(),
+                loginRequest.password());
+
+        return getAuthenticationManager().authenticate(authToken);
+    }
+}

--- a/src/main/java/com/personal/interview/global/security/handler/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/personal/interview/global/security/handler/JwtAccessDeniedHandler.java
@@ -1,0 +1,29 @@
+package com.personal.interview.global.security.handler;
+
+import java.io.IOException;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import tools.jackson.databind.ObjectMapper;
+import com.personal.interview.global.exception.ErrorCode;
+import com.personal.interview.util.filter.FilterExceptionUtil;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+            AccessDeniedException accessDeniedException) throws IOException {
+        ErrorCode errorCode = ErrorCode.ACCESS_DENIED;
+
+        FilterExceptionUtil.sendErrorResponse(response, errorCode, objectMapper);
+    }
+}

--- a/src/main/java/com/personal/interview/global/security/handler/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/personal/interview/global/security/handler/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,30 @@
+package com.personal.interview.global.security.handler;
+
+import java.io.IOException;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import tools.jackson.databind.ObjectMapper;
+import com.personal.interview.global.exception.ErrorCode;
+import com.personal.interview.util.filter.FilterExceptionUtil;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+            AuthenticationException authException) throws IOException {
+
+        ErrorCode errorCode = ErrorCode.INVALID_TOKEN;
+
+        FilterExceptionUtil.sendErrorResponse(response, errorCode, objectMapper);
+    }
+}

--- a/src/main/java/com/personal/interview/global/security/handler/JwtAuthenticationFailureHandler.java
+++ b/src/main/java/com/personal/interview/global/security/handler/JwtAuthenticationFailureHandler.java
@@ -1,0 +1,28 @@
+package com.personal.interview.global.security.handler;
+
+import java.io.IOException;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+
+import tools.jackson.databind.ObjectMapper;
+import com.personal.interview.global.exception.ErrorCode;
+import com.personal.interview.util.filter.FilterExceptionUtil;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFailureHandler implements AuthenticationFailureHandler {
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+            AuthenticationException exception) throws IOException {
+
+        ErrorCode errorCode = ErrorCode.INVALID_CREDENTIALS;
+
+        FilterExceptionUtil.sendErrorResponse(response, errorCode, objectMapper);
+    }
+}

--- a/src/main/java/com/personal/interview/global/security/handler/JwtAuthenticationSuccessHandler.java
+++ b/src/main/java/com/personal/interview/global/security/handler/JwtAuthenticationSuccessHandler.java
@@ -1,0 +1,63 @@
+package com.personal.interview.global.security.handler;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+
+import tools.jackson.databind.ObjectMapper;
+import com.personal.interview.domain.auth.controller.dto.TokenResponse;
+import com.personal.interview.domain.auth.entity.UserRefreshToken;
+import com.personal.interview.domain.auth.repository.UserRefreshTokenRepository;
+import com.personal.interview.domain.auth.service.AuthService;
+import com.personal.interview.domain.user.entity.UserId;
+import com.personal.interview.domain.user.entity.vo.UserRole;
+import com.personal.interview.global.security.JwtTokenProvider;
+import com.personal.interview.global.security.service.RefreshTokenService;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 로그인 인증 성공처리 handler
+ */
+@RequiredArgsConstructor
+public class JwtAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+    private final JwtTokenProvider jwtTokenProvider;
+    private final ObjectMapper objectMapper;
+    private final RefreshTokenService refreshTokenService;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+            Authentication authentication) throws IOException {
+        final Long userId = Long.parseLong(authentication.getName());
+        final String role = getRole(authentication);
+
+        final String accessToken = jwtTokenProvider.createAccessToken(userId, role);
+        final String refreshToken = jwtTokenProvider.createRefreshToken(userId, role);
+
+        refreshTokenService.rotateRefreshToken(new UserId(userId), refreshToken);
+
+        TokenResponse tokenResponse = new TokenResponse(accessToken, refreshToken);
+        writeJsonResponse(response, tokenResponse);
+    }
+
+    private String getRole(Authentication authentication) {
+        return authentication.getAuthorities().stream()
+                .findFirst()
+                .map(GrantedAuthority::getAuthority)
+                .orElse(UserRole.ROLE_DRAFT.name());
+    }
+
+    private void writeJsonResponse(HttpServletResponse response, TokenResponse tokenResponse) throws IOException {
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        objectMapper.writeValue(response.getWriter(), tokenResponse);
+    }
+}

--- a/src/main/java/com/personal/interview/global/security/handler/JwtAuthenticationSuccessHandler.java
+++ b/src/main/java/com/personal/interview/global/security/handler/JwtAuthenticationSuccessHandler.java
@@ -1,8 +1,6 @@
 package com.personal.interview.global.security.handler;
 
 import java.io.IOException;
-import java.time.LocalDateTime;
-import java.util.Optional;
 
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
@@ -11,9 +9,6 @@ import org.springframework.security.web.authentication.AuthenticationSuccessHand
 
 import tools.jackson.databind.ObjectMapper;
 import com.personal.interview.domain.auth.controller.dto.TokenResponse;
-import com.personal.interview.domain.auth.entity.UserRefreshToken;
-import com.personal.interview.domain.auth.repository.UserRefreshTokenRepository;
-import com.personal.interview.domain.auth.service.AuthService;
 import com.personal.interview.domain.user.entity.UserId;
 import com.personal.interview.domain.user.entity.vo.UserRole;
 import com.personal.interview.global.security.JwtTokenProvider;

--- a/src/main/java/com/personal/interview/global/security/service/CustomUserDetailsService.java
+++ b/src/main/java/com/personal/interview/global/security/service/CustomUserDetailsService.java
@@ -1,0 +1,32 @@
+package com.personal.interview.global.security.service;
+
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import com.personal.interview.domain.user.entity.User;
+import com.personal.interview.domain.user.entity.vo.Email;
+import com.personal.interview.domain.user.repository.UserRepository;
+
+import java.util.Collections;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(new Email(email))
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + email));
+
+        return new org.springframework.security.core.userdetails.User(
+                String.valueOf(user.getId().longValue()),
+                user.getPassword(),
+                Collections.singletonList(new SimpleGrantedAuthority(user.getRole().name())));
+    }
+}

--- a/src/main/java/com/personal/interview/global/security/service/RefreshTokenService.java
+++ b/src/main/java/com/personal/interview/global/security/service/RefreshTokenService.java
@@ -21,17 +21,17 @@ public class RefreshTokenService {
 
 	@Transactional
 	public void rotateRefreshToken(UserId userId, String refreshToken) {
-		String hashedToken = AuthService.hashToken(refreshToken);
+		String salt = AuthService.generateSalt();
+		String hashedToken = AuthService.hashToken(refreshToken, salt);
 
-		// 2. 만료 시간 계산
 		LocalDateTime expiryAt = LocalDateTime.now()
-			.plusSeconds(jwtTokenProvider.getRefreshExpirationMs() / 1000);
+				.plusSeconds(jwtTokenProvider.getRefreshExpirationMs() / 1000);
 
-		// 3. 존재하면 업데이트, 없으면 새로 생성 (RTR)
+		// 존재하면 회전(이전 토큰 보관), 없으면 새로 생성
 		userRefreshTokenRepository.findByUserId(userId)
-			.ifPresentOrElse(
-				existing -> existing.updateRefreshToken(hashedToken, expiryAt),
-				() -> userRefreshTokenRepository.save(UserRefreshToken.create(userId, hashedToken, expiryAt))
-			);
+				.ifPresentOrElse(
+						existing -> existing.rotateToken(hashedToken, salt, expiryAt),
+						() -> userRefreshTokenRepository
+								.save(UserRefreshToken.create(userId, hashedToken, salt, expiryAt)));
 	}
 }

--- a/src/main/java/com/personal/interview/global/security/service/RefreshTokenService.java
+++ b/src/main/java/com/personal/interview/global/security/service/RefreshTokenService.java
@@ -1,0 +1,37 @@
+package com.personal.interview.global.security.service;
+
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.personal.interview.domain.auth.entity.UserRefreshToken;
+import com.personal.interview.domain.auth.repository.UserRefreshTokenRepository;
+import com.personal.interview.domain.auth.service.AuthService;
+import com.personal.interview.domain.user.entity.UserId;
+import com.personal.interview.global.security.JwtTokenProvider;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+	private final UserRefreshTokenRepository userRefreshTokenRepository;
+	private final JwtTokenProvider jwtTokenProvider;
+
+	@Transactional
+	public void rotateRefreshToken(UserId userId, String refreshToken) {
+		String hashedToken = AuthService.hashToken(refreshToken);
+
+		// 2. 만료 시간 계산
+		LocalDateTime expiryAt = LocalDateTime.now()
+			.plusSeconds(jwtTokenProvider.getRefreshExpirationMs() / 1000);
+
+		// 3. 존재하면 업데이트, 없으면 새로 생성 (RTR)
+		userRefreshTokenRepository.findByUserId(userId)
+			.ifPresentOrElse(
+				existing -> existing.updateRefreshToken(hashedToken, expiryAt),
+				() -> userRefreshTokenRepository.save(UserRefreshToken.create(userId, hashedToken, expiryAt))
+			);
+	}
+}

--- a/src/main/java/com/personal/interview/util/filter/FilterExceptionUtil.java
+++ b/src/main/java/com/personal/interview/util/filter/FilterExceptionUtil.java
@@ -1,0 +1,56 @@
+package com.personal.interview.util.filter;
+
+import java.io.IOException;
+
+import org.springframework.http.MediaType;
+
+import com.personal.interview.global.exception.ErrorCode;
+import com.personal.interview.global.exception.ErrorResponse;
+
+import jakarta.servlet.http.HttpServletResponse;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Filter 및 Security Handler 계층에서 예외나 인증 실패가 발생했을 때
+ * 일관된 JSON 형식의 에러 응답을 작성하기 위한 유틸리티 클래스입니다.
+ */
+public class FilterExceptionUtil {
+
+    /**
+     * 기본 ErrorCode의 메시지를 사용하여 에러 응답을 작성합니다.
+     *
+     * @param response     HttpServletResponse 객체
+     * @param errorCode    에러 코드 객체 (상태 코드, 코드, 메시지 포함)
+     * @param objectMapper ErrorResponse 객체를 JSON으로 직렬화하기 위한 ObjectMapper
+     * @throws IOException 스트림에 쓰는 과정에서 발생할 수 있는 I/O 예외
+     */
+    public static void sendErrorResponse(HttpServletResponse response, ErrorCode errorCode, ObjectMapper objectMapper)
+            throws IOException {
+        sendErrorResponse(response, errorCode, errorCode.getMessage(), objectMapper);
+    }
+
+    /**
+     * 커스텀 메시지를 사용하여 에러 응답을 작성합니다.
+     * Validator 등을 통해 생성된 구체적인 에러 사유를 사용할 때 적합합니다.
+     *
+     * @param response     HttpServletResponse 객체
+     * @param errorCode    에러 코드 객체 (상태 코드, 식별용 코드 문자열 포함)
+     * @param message      에러 응답에 포함될 구체적인 커스텀 메시지
+     * @param objectMapper ErrorResponse 객체를 JSON으로 직렬화하기 위한 ObjectMapper
+     * @throws IOException 스트림에 쓰는 과정에서 발생할 수 있는 I/O 예외
+     */
+    public static void sendErrorResponse(HttpServletResponse response, ErrorCode errorCode, String message,
+            ObjectMapper objectMapper) throws IOException {
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .status(errorCode.getStatus().value())
+                .code(errorCode.getCode())
+                .message(message)
+                .build();
+
+        response.setStatus(errorCode.getStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        objectMapper.writeValue(response.getWriter(), errorResponse);
+    }
+}

--- a/src/main/java/com/personal/interview/util/validator/SecurityFilterValidationException.java
+++ b/src/main/java/com/personal/interview/util/validator/SecurityFilterValidationException.java
@@ -1,0 +1,9 @@
+package com.personal.interview.util.validator;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class SecurityFilterValidationException extends AuthenticationException {
+    public SecurityFilterValidationException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/com/personal/interview/util/validator/SecurityValidatorUtil.java
+++ b/src/main/java/com/personal/interview/util/validator/SecurityValidatorUtil.java
@@ -1,0 +1,49 @@
+package com.personal.interview.util.validator;
+
+import java.io.IOException;
+import java.util.Set;
+
+import com.personal.interview.global.exception.ErrorCode;
+import com.personal.interview.util.filter.FilterExceptionUtil;
+
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
+import lombok.RequiredArgsConstructor;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Security Filter 레이어 내에서 DTO 유효성 검증을 수행하는 유틸리티 클래스입니다.
+ * 일반적인 Controller의 @Valid와 달리, 필터 단에서 발생하는 검증 오류를 가로채어
+ * 표준화된 에러 응답(JSON)을 반환하고 인증 프로세스를 중단시킵니다.
+ */
+@Component
+@RequiredArgsConstructor
+public class SecurityValidatorUtil {
+	private final Validator validator;
+	private final ObjectMapper objectMapper;
+
+	/**
+	 * 대상 객체(target)의 유효성을 검증합니다.
+	 * * @param target   검증할 DTO 객체 (예: LoginRequest)
+	 * @param response 에러 발생 시 응답을 작성할 HttpServletResponse
+	 * @param <T>      검증 대상의 타입
+	 * @throws IOException                      응답 작성 중 발생하는 예외
+	 * @throws SecurityFilterValidationException 검증 실패 시 발생하여 필터 체인을 중단시킴
+	 */
+	public <T> void validate(T target, HttpServletResponse response) throws IOException {
+		Set<ConstraintViolation<T>> violations = validator.validate(target);
+
+		if (!violations.isEmpty()) {
+			String errorMessage = violations.iterator().next().getMessage();
+
+			ErrorCode errorCode = ErrorCode.INVALID_CREDENTIALS;
+
+			FilterExceptionUtil.sendErrorResponse(response, errorCode, errorMessage, objectMapper);
+
+			throw new SecurityFilterValidationException(errorMessage);
+		}
+	}
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -24,3 +24,4 @@ app:
     secret-key: ${JWT_SECRET_KEY:myDefaultSecretKeyForDevelopmentPurposeOnly12345678901234567890}
     access-expiration-ms: 1800000  # 30분
     refresh-expiration-ms: 604800000  # 7일
+    refresh-grace-period-seconds: 10  # RTR 동시성 유예 기간

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -20,3 +20,7 @@ app:
     base-url: ${EMAIL_BASE_URL:http://localhost:8080}
     sender-email: ${EMAIL_SENDER:noreply@personal-interview.com}
     sender-name: Personal Interview
+  jwt:
+    secret-key: ${JWT_SECRET_KEY:myDefaultSecretKeyForDevelopmentPurposeOnly12345678901234567890}
+    access-expiration-ms: 1800000  # 30분
+    refresh-expiration-ms: 604800000  # 7일

--- a/src/test/java/com/personal/interview/domain/auth/controller/EmailVerifyControllerTest.java
+++ b/src/test/java/com/personal/interview/domain/auth/controller/EmailVerifyControllerTest.java
@@ -21,24 +21,49 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.personal.interview.domain.auth.AuthPropertiesFixture;
 import com.personal.interview.domain.auth.entity.EmailVerify;
+import com.personal.interview.domain.auth.repository.UserRefreshTokenRepository;
 import com.personal.interview.domain.auth.service.VerifyService;
 import com.personal.interview.domain.user.entity.UserId;
 import com.personal.interview.global.config.SecurityConfig;
 import com.personal.interview.global.config.properties.AuthProperties;
 import com.personal.interview.global.exception.DomainException;
 import com.personal.interview.global.exception.BaseErrorCode;
+import com.personal.interview.global.security.JwtTokenProvider;
+import com.personal.interview.global.security.aop.AuthorizeAspect;
+import com.personal.interview.global.security.handler.JwtAccessDeniedHandler;
+import com.personal.interview.global.security.handler.JwtAuthenticationEntryPoint;
+import com.personal.interview.global.security.service.RefreshTokenService;
+import com.personal.interview.util.validator.SecurityValidatorUtil;
 
 import org.springframework.http.HttpStatus;
 
 @WebMvcTest(EmailVerifyController.class)
-@Import(SecurityConfig.class)
+@Import({ SecurityConfig.class, AuthorizeAspect.class,
+        org.springframework.boot.autoconfigure.aop.AopAutoConfiguration.class })
 class EmailVerifyControllerTest {
-
     @Autowired
     private MockMvc mockMvc;
 
     @MockitoBean
     private VerifyService verifyService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private UserRefreshTokenRepository userRefreshTokenRepository;
+
+    @MockitoBean
+    private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    @MockitoBean
+    private JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
+    @MockitoBean
+    private SecurityValidatorUtil securityValidatorUtil;
+
+    @MockitoBean
+    private RefreshTokenService refreshTokenService;
 
     private AuthProperties authProperties;
 
@@ -48,8 +73,8 @@ class EmailVerifyControllerTest {
     }
 
     @Test
-    @DisplayName("인증 메일 발송 성공")
-    @WithMockUser(username = "1")
+    @DisplayName("인증 메일 발송 성공 (ROLE_DRAFT 권한 소지)")
+    @WithMockUser(username = "1", roles = "DRAFT")
     void sendVerificationEmail_Success() throws Exception {
         // given
         EmailVerify mockVerify = EmailVerify.create(new UserId(1L), authProperties);
@@ -61,6 +86,17 @@ class EmailVerifyControllerTest {
                 .with(csrf()))
                 .andDo(print())
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("인증 메일 발송 실패 - 권한 불일치 (ROLE_DRAFT 권한 소지)")
+    @WithMockUser(username = "1", roles = "USER")
+    void sendVerificationEmail_Fail_Forbidden() throws Exception {
+        // when & then
+        mockMvc.perform(post("/api/auth/email/send")
+                .with(csrf()))
+                .andDo(print())
+                .andExpect(status().isForbidden());
     }
 
     @Test

--- a/src/test/java/com/personal/interview/domain/auth/entity/UserRefreshTokenTest.java
+++ b/src/test/java/com/personal/interview/domain/auth/entity/UserRefreshTokenTest.java
@@ -1,0 +1,126 @@
+package com.personal.interview.domain.auth.entity;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.personal.interview.domain.user.entity.UserId;
+
+class UserRefreshTokenTest {
+
+    private static final UserId TEST_USER_ID = new UserId(1L);
+    private static final String HASH = "hashedToken123";
+    private static final String SALT = "salt123";
+
+    private void setCreatedAt(UserRefreshToken token, LocalDateTime createdAt) {
+        try {
+            Field field = UserRefreshToken.class.getDeclaredField("createdAt");
+            field.setAccessible(true);
+            field.set(token, createdAt);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Nested
+    @DisplayName("create")
+    class Create {
+
+        @Test
+        @DisplayName("정상적으로 생성되면 모든 필드가 설정된다")
+        void create_Success() {
+            LocalDateTime expiryAt = LocalDateTime.now().plusDays(7);
+
+            UserRefreshToken token = UserRefreshToken.create(TEST_USER_ID, HASH, SALT, expiryAt);
+
+            assertThat(token.getUserId()).isEqualTo(TEST_USER_ID);
+            assertThat(token.getRefreshToken()).isEqualTo(HASH);
+            assertThat(token.getSalt()).isEqualTo(SALT);
+            assertThat(token.getExpiryAt()).isEqualTo(expiryAt);
+            assertThat(token.getCreatedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("null 값이 들어오면 NullPointerException을 발생시킨다")
+        void create_NullValues() {
+            assertThatThrownBy(() -> UserRefreshToken.create(TEST_USER_ID, null, SALT, LocalDateTime.now()))
+                    .isInstanceOf(NullPointerException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("rotateToken")
+    class RotateToken {
+
+        @Test
+        @DisplayName("회전 시 토큰, salt, 만료시간, createdAt이 갱신된다")
+        void rotateToken_UpdatesAllFields() {
+            UserRefreshToken token = UserRefreshToken.create(
+                    TEST_USER_ID, HASH, SALT, LocalDateTime.now().plusDays(7));
+
+            String newHash = "newHashedToken456";
+            String newSalt = "newSalt456";
+            LocalDateTime newExpiry = LocalDateTime.now().plusDays(14);
+            LocalDateTime beforeRotate = LocalDateTime.now();
+
+            token.rotateToken(newHash, newSalt, newExpiry);
+
+            assertThat(token.getRefreshToken()).isEqualTo(newHash);
+            assertThat(token.getSalt()).isEqualTo(newSalt);
+            assertThat(token.getExpiryAt()).isEqualTo(newExpiry);
+            assertThat(token.getCreatedAt()).isAfterOrEqualTo(beforeRotate);
+        }
+    }
+
+    @Nested
+    @DisplayName("isWithinGracePeriod")
+    class IsWithinGracePeriod {
+
+        @Test
+        @DisplayName("createdAt이 grace period 내이면 true를 반환한다")
+        void withinGracePeriod_ReturnsTrue() {
+            UserRefreshToken token = UserRefreshToken.create(
+                    TEST_USER_ID, HASH, SALT, LocalDateTime.now().plusDays(7));
+
+            assertThat(token.isWithinGracePeriod(10L)).isTrue();
+        }
+
+        @Test
+        @DisplayName("createdAt이 grace period 밖이면 false를 반환한다")
+        void outsideGracePeriod_ReturnsFalse() {
+            UserRefreshToken token = UserRefreshToken.create(
+                    TEST_USER_ID, HASH, SALT, LocalDateTime.now().plusDays(7));
+            setCreatedAt(token, LocalDateTime.now().minusMinutes(5));
+
+            assertThat(token.isWithinGracePeriod(10L)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("isExpired")
+    class IsExpired {
+
+        @Test
+        @DisplayName("만료 시간이 지나면 true를 반환한다")
+        void expired_ReturnsTrue() {
+            UserRefreshToken token = UserRefreshToken.create(
+                    TEST_USER_ID, HASH, SALT, LocalDateTime.now().minusDays(1));
+
+            assertThat(token.isExpired()).isTrue();
+        }
+
+        @Test
+        @DisplayName("만료 시간 전이면 false를 반환한다")
+        void notExpired_ReturnsFalse() {
+            UserRefreshToken token = UserRefreshToken.create(
+                    TEST_USER_ID, HASH, SALT, LocalDateTime.now().plusDays(7));
+
+            assertThat(token.isExpired()).isFalse();
+        }
+    }
+}

--- a/src/test/java/com/personal/interview/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/personal/interview/domain/auth/service/AuthServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
 
+import java.lang.reflect.Field;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.Optional;
@@ -15,6 +16,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -44,30 +46,44 @@ class AuthServiceTest {
     @Mock
     private RefreshTokenService refreshTokenService;
 
+    private static final String TEST_SALT = "0123456789abcdef0123456789abcdef";
+
+    // ── 헬퍼: createdAt을 리플렉션으로 조작 ──
+    private void setCreatedAt(UserRefreshToken token, LocalDateTime createdAt) {
+        try {
+            Field field = UserRefreshToken.class.getDeclaredField("createdAt");
+            field.setAccessible(true);
+            field.set(token, createdAt);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Authentication mockAuth(UserId userId) {
+        return new UsernamePasswordAuthenticationToken(
+                String.valueOf(userId), null,
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER")));
+    }
+
     @Nested
-    @DisplayName("Refresh Token 재발급")
-    class Refresh {
+    @DisplayName("Refresh Token 재발급 - 정상 흐름")
+    class RefreshSuccess {
 
         @Test
-        @DisplayName("정상적인 Refresh Token으로 재발급 시, 새로운 Access/Refresh Token을 반환한다")
+        @DisplayName("정상 Refresh Token으로 재발급 시, 새 Access/Refresh Token을 반환하고 RTR을 수행한다")
         void refresh_Success() {
             // given
             String validToken = "valid.refresh.token";
             UserId userId = new UserId(1L);
-            String hashedToken = AuthService.hashToken(validToken);
+            String hashedToken = AuthService.hashToken(validToken, TEST_SALT);
 
             given(jwtTokenProvider.validateToken(validToken)).willReturn(true);
             given(jwtTokenProvider.getUserId(validToken)).willReturn(userId.longValue());
 
             UserRefreshToken storedToken = UserRefreshToken.create(
-                    userId, hashedToken, LocalDateTime.now().plusDays(7));
+                    userId, hashedToken, TEST_SALT, LocalDateTime.now().plusDays(7));
             given(userRefreshTokenRepository.findByUserId(userId)).willReturn(Optional.of(storedToken));
-
-            Authentication auth = new UsernamePasswordAuthenticationToken(
-                    String.valueOf(userId), null,
-                    Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER")));
-            given(jwtTokenProvider.getAuthentication(validToken)).willReturn(auth);
-
+            given(jwtTokenProvider.getAuthentication(validToken)).willReturn(mockAuth(userId));
             given(jwtTokenProvider.createAccessToken(eq(userId.longValue()), eq("ROLE_USER")))
                     .willReturn("new.access.token");
             given(jwtTokenProvider.createRefreshToken(eq(userId.longValue()), eq("ROLE_USER")))
@@ -79,14 +95,115 @@ class AuthServiceTest {
             // then
             assertThat(response.accessToken()).isEqualTo("new.access.token");
             assertThat(response.refreshToken()).isEqualTo("new.refresh.token");
-
-            // RefreshTokenService.rotateRefreshToken을 통해 새로운 토큰 생성이 위임되었는지 확인
             verify(refreshTokenService).rotateRefreshToken(userId, "new.refresh.token");
+        }
+    }
+
+    @Nested
+    @DisplayName("Refresh Token 재발급 - Grace Period (동시성 제어)")
+    class GracePeriod {
+
+        @Test
+        @DisplayName("Grace Period 내 동시 요청: 토큰 해시 불일치이지만 rotatedAt이 유예 기간 내이면 회전 없이 제출 토큰을 반환한다")
+        void refresh_GracePeriodHit_ReturnsSubmittedToken() {
+            // given
+            String oldToken = "old.refresh.token";
+            UserId userId = new UserId(1L);
+
+            given(jwtTokenProvider.validateToken(oldToken)).willReturn(true);
+            given(jwtTokenProvider.getUserId(oldToken)).willReturn(userId.longValue());
+
+            // DB에는 선행 스레드가 이미 회전한 다른 해시가 저장됨 (oldToken과 불일치)
+            String differentHash = AuthService.hashToken("new.rotated.token", TEST_SALT);
+            UserRefreshToken storedToken = UserRefreshToken.create(
+                    userId, differentHash, TEST_SALT, LocalDateTime.now().plusDays(7));
+            // createdAt이 방금 (grace period 내) → create 시 now()로 설정되므로 그대로 사용
+
+            given(userRefreshTokenRepository.findByUserId(userId)).willReturn(Optional.of(storedToken));
+            given(jwtTokenProvider.getRefreshGracePeriodSeconds()).willReturn(10L);
+            given(jwtTokenProvider.getAuthentication(oldToken)).willReturn(mockAuth(userId));
+            given(jwtTokenProvider.createAccessToken(eq(userId.longValue()), eq("ROLE_USER")))
+                    .willReturn("grace.access.token");
+
+            // when
+            TokenResponse response = authService.refresh(new RefreshTokenRequest(oldToken));
+
+            // then - 회전 없이 새 Access Token + 제출된 Refresh Token 반환
+            assertThat(response.accessToken()).isEqualTo("grace.access.token");
+            assertThat(response.refreshToken()).isEqualTo(oldToken);
+            verify(refreshTokenService, never()).rotateRefreshToken(any(), anyString());
         }
 
         @Test
-        @DisplayName("만료된 Refresh Token 요청 시, 해당 사용자의 모든 세션을 무효화하고 예외를 발생시킨다")
-        void refresh_ExpiredToken_InvalidatesAllSessions() {
+        @DisplayName("Grace Period 만료 후 이전 토큰 재사용: 탈취로 감지하여 전체 세션을 무효화한다")
+        void refresh_GracePeriodExpired_DetectsReuse() {
+            // given
+            String reusedToken = "reused.refresh.token";
+            UserId userId = new UserId(1L);
+
+            given(jwtTokenProvider.validateToken(reusedToken)).willReturn(true);
+            given(jwtTokenProvider.getUserId(reusedToken)).willReturn(userId.longValue());
+
+            // DB에는 다른 해시가 저장 (이미 RTR로 교체된 상태)
+            String differentHash = AuthService.hashToken("different.token", TEST_SALT);
+            UserRefreshToken storedToken = UserRefreshToken.create(
+                    userId, differentHash, TEST_SALT, LocalDateTime.now().plusDays(7));
+            // createdAt을 5분 전으로 (grace period 밖)
+            setCreatedAt(storedToken, LocalDateTime.now().minusMinutes(5));
+
+            given(userRefreshTokenRepository.findByUserId(userId)).willReturn(Optional.of(storedToken));
+            given(jwtTokenProvider.getRefreshGracePeriodSeconds()).willReturn(10L);
+
+            // when & then
+            assertThatThrownBy(() -> authService.refresh(new RefreshTokenRequest(reusedToken)))
+                    .isInstanceOf(DomainException.class)
+                    .satisfies(ex -> {
+                        DomainException domainEx = (DomainException) ex;
+                        assertThat(domainEx.getErrorCode()).isEqualTo(ErrorCode.REFRESH_TOKEN_REUSE_DETECTED);
+                    });
+
+            then(userRefreshTokenRepository).should().deleteByUserId(userId);
+        }
+
+        @Test
+        @DisplayName("OptimisticLock 충돌 시, 새 Access Token과 제출된 Refresh Token을 반환한다")
+        void refresh_OptimisticLockConflict_ReturnsSubmittedToken() {
+            // given
+            String validToken = "valid.refresh.token";
+            UserId userId = new UserId(1L);
+            String hashedToken = AuthService.hashToken(validToken, TEST_SALT);
+
+            given(jwtTokenProvider.validateToken(validToken)).willReturn(true);
+            given(jwtTokenProvider.getUserId(validToken)).willReturn(userId.longValue());
+
+            UserRefreshToken storedToken = UserRefreshToken.create(
+                    userId, hashedToken, TEST_SALT, LocalDateTime.now().plusDays(7));
+            given(userRefreshTokenRepository.findByUserId(userId)).willReturn(Optional.of(storedToken));
+            given(jwtTokenProvider.getAuthentication(validToken)).willReturn(mockAuth(userId));
+            given(jwtTokenProvider.createAccessToken(eq(userId.longValue()), eq("ROLE_USER")))
+                    .willReturn("new.access.token");
+            given(jwtTokenProvider.createRefreshToken(eq(userId.longValue()), eq("ROLE_USER")))
+                    .willReturn("new.refresh.token");
+
+            willThrow(new ObjectOptimisticLockingFailureException(UserRefreshToken.class.getName(), "conflict"))
+                    .given(refreshTokenService).rotateRefreshToken(any(UserId.class), anyString());
+
+            // when
+            TokenResponse response = authService.refresh(new RefreshTokenRequest(validToken));
+
+            // then - 새 Access Token + 제출된 Refresh Token (grace period 내 재사용 가능)
+            assertThat(response.accessToken()).isEqualTo("new.access.token");
+            assertThat(response.refreshToken()).isEqualTo(validToken);
+        }
+    }
+
+    @Nested
+    @DisplayName("Refresh Token 재발급 - 예외 흐름")
+    class RefreshException {
+
+        @Test
+        @DisplayName("JWT 유효성 검증 실패(만료/위변조) 시, 해당 사용자의 모든 세션을 무효화하고 예외를 발생시킨다")
+        void refresh_InvalidJwt_InvalidatesAllSessions() {
             // given
             String expiredToken = "expired.refresh.token";
             UserId userId = new UserId(1L);
@@ -102,39 +219,11 @@ class AuthServiceTest {
                         assertThat(domainEx.getErrorCode()).isEqualTo(ErrorCode.REFRESH_TOKEN_REUSE_DETECTED);
                     });
 
-            // 전체 세션 무효화 확인
             then(userRefreshTokenRepository).should().deleteByUserId(userId);
         }
 
         @Test
-        @DisplayName("이미 교체된(재사용된) Refresh Token 요청 시, 전체 세션을 무효화하고 예외를 발생시킨다")
-        void refresh_ReusedToken_InvalidatesAllSessions() {
-            // given
-            String reusedToken = "reused.refresh.token";
-            UserId userId = new UserId(1L);
-
-            given(jwtTokenProvider.validateToken(reusedToken)).willReturn(true);
-            given(jwtTokenProvider.getUserId(reusedToken)).willReturn(userId.longValue());
-
-            // DB에는 다른 해시값이 저장되어 있음 (이미 RTR로 교체된 상태)
-            String differentHash = AuthService.hashToken("different.token");
-            UserRefreshToken storedToken = UserRefreshToken.create(
-                    userId, differentHash, LocalDateTime.now().plusDays(7));
-            given(userRefreshTokenRepository.findByUserId(userId)).willReturn(Optional.of(storedToken));
-
-            // when & then
-            assertThatThrownBy(() -> authService.refresh(new RefreshTokenRequest(reusedToken)))
-                    .isInstanceOf(DomainException.class)
-                    .satisfies(ex -> {
-                        DomainException domainEx = (DomainException) ex;
-                        assertThat(domainEx.getErrorCode()).isEqualTo(ErrorCode.REFRESH_TOKEN_REUSE_DETECTED);
-                    });
-
-            then(userRefreshTokenRepository).should().deleteByUserId(userId);
-        }
-
-        @Test
-        @DisplayName("DB에 Refresh Token이 존재하지 않으면 예외를 발생시킨다")
+        @DisplayName("DB에 Refresh Token이 존재하지 않으면 REFRESH_TOKEN_NOT_FOUND 예외를 발생시킨다")
         void refresh_NotFoundInDb() {
             // given
             String validToken = "valid.refresh.token";
@@ -154,19 +243,18 @@ class AuthServiceTest {
         }
 
         @Test
-        @DisplayName("DB의 Refresh Token이 만료된 경우, 세션을 무효화하고 예외를 발생시킨다")
+        @DisplayName("DB의 Refresh Token이 만료된 경우, 세션을 무효화하고 REFRESH_TOKEN_EXPIRED 예외를 발생시킨다")
         void refresh_StoredTokenExpired_Deletes() {
             // given
             String validToken = "valid.refresh.token";
             UserId userId = new UserId(1L);
-            String hashedToken = AuthService.hashToken(validToken);
+            String hashedToken = AuthService.hashToken(validToken, TEST_SALT);
 
             given(jwtTokenProvider.validateToken(validToken)).willReturn(true);
             given(jwtTokenProvider.getUserId(validToken)).willReturn(userId.longValue());
 
-            // DB에 만료된 토큰이 저장된 상태
             UserRefreshToken expiredStoredToken = UserRefreshToken.create(
-                    userId, hashedToken, LocalDateTime.now().minusDays(1));
+                    userId, hashedToken, TEST_SALT, LocalDateTime.now().minusDays(1));
             given(userRefreshTokenRepository.findByUserId(userId)).willReturn(Optional.of(expiredStoredToken));
 
             // when & then
@@ -179,27 +267,51 @@ class AuthServiceTest {
 
             then(userRefreshTokenRepository).should().deleteByUserId(userId);
         }
+
+        @Test
+        @DisplayName("완전히 손상된 토큰(userId 추출 불가)의 경우에도 예외를 정상적으로 발생시킨다")
+        void refresh_CompletelyCorruptedToken() {
+            // given
+            String corruptedToken = "corrupted.token";
+
+            given(jwtTokenProvider.validateToken(corruptedToken)).willReturn(false);
+            given(jwtTokenProvider.getUserIdFromExpiredToken(corruptedToken))
+                    .willThrow(new RuntimeException("파싱 불가"));
+
+            // when & then
+            assertThatThrownBy(() -> authService.refresh(new RefreshTokenRequest(corruptedToken)))
+                    .isInstanceOf(DomainException.class)
+                    .satisfies(ex -> {
+                        DomainException domainEx = (DomainException) ex;
+                        assertThat(domainEx.getErrorCode()).isEqualTo(ErrorCode.REFRESH_TOKEN_REUSE_DETECTED);
+                    });
+
+            // userId 추출 실패 시 deleteByUserId는 호출되지 않음
+            then(userRefreshTokenRepository).should(never()).deleteByUserId(any());
+        }
     }
 
     @Nested
-    @DisplayName("SHA-256 해싱")
+    @DisplayName("SHA-256 + SALT 해싱")
     class HashToken {
 
         @Test
-        @DisplayName("동일한 토큰 입력 시 항상 동일한 해시값을 반환한다")
+        @DisplayName("동일한 토큰과 SALT 입력 시 항상 동일한 해시값을 반환한다")
         void hashToken_Deterministic() {
             String token = "test.token.value";
-            String hash1 = AuthService.hashToken(token);
-            String hash2 = AuthService.hashToken(token);
+            String salt = "testSalt123";
+            String hash1 = AuthService.hashToken(token, salt);
+            String hash2 = AuthService.hashToken(token, salt);
 
             assertThat(hash1).isEqualTo(hash2);
         }
 
         @Test
-        @DisplayName("다른 토큰 입력 시 다른 해시값을 반환한다")
-        void hashToken_DifferentInputs() {
-            String hash1 = AuthService.hashToken("token1");
-            String hash2 = AuthService.hashToken("token2");
+        @DisplayName("다른 SALT 입력 시 다른 해시값을 반환한다")
+        void hashToken_DifferentSalts() {
+            String token = "test.token.value";
+            String hash1 = AuthService.hashToken(token, "salt1");
+            String hash2 = AuthService.hashToken(token, "salt2");
 
             assertThat(hash1).isNotEqualTo(hash2);
         }
@@ -207,10 +319,28 @@ class AuthServiceTest {
         @Test
         @DisplayName("해시값은 64자의 16진수 문자열이다 (SHA-256)")
         void hashToken_Format() {
-            String hash = AuthService.hashToken("test.token");
+            String hash = AuthService.hashToken("test.token", "testSalt");
 
             assertThat(hash).hasSize(64);
             assertThat(hash).matches("[0-9a-f]+");
+        }
+
+        @Test
+        @DisplayName("generateSalt()는 32자의 16진수 문자열을 반환한다")
+        void generateSalt_Format() {
+            String salt = AuthService.generateSalt();
+
+            assertThat(salt).hasSize(32);
+            assertThat(salt).matches("[0-9a-f]+");
+        }
+
+        @Test
+        @DisplayName("generateSalt()는 매번 다른 값을 반환한다")
+        void generateSalt_Unique() {
+            String salt1 = AuthService.generateSalt();
+            String salt2 = AuthService.generateSalt();
+
+            assertThat(salt1).isNotEqualTo(salt2);
         }
     }
 }

--- a/src/test/java/com/personal/interview/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/personal/interview/domain/auth/service/AuthServiceTest.java
@@ -1,0 +1,216 @@
+package com.personal.interview.domain.auth.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import com.personal.interview.domain.auth.controller.dto.RefreshTokenRequest;
+import com.personal.interview.domain.auth.controller.dto.TokenResponse;
+import com.personal.interview.domain.auth.entity.UserRefreshToken;
+import com.personal.interview.domain.auth.repository.UserRefreshTokenRepository;
+import com.personal.interview.domain.user.entity.UserId;
+import com.personal.interview.global.exception.DomainException;
+import com.personal.interview.global.exception.ErrorCode;
+import com.personal.interview.global.security.JwtTokenProvider;
+import com.personal.interview.global.security.service.RefreshTokenService;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Mock
+    private UserRefreshTokenRepository userRefreshTokenRepository;
+
+    @Mock
+    private RefreshTokenService refreshTokenService;
+
+    @Nested
+    @DisplayName("Refresh Token 재발급")
+    class Refresh {
+
+        @Test
+        @DisplayName("정상적인 Refresh Token으로 재발급 시, 새로운 Access/Refresh Token을 반환한다")
+        void refresh_Success() {
+            // given
+            String validToken = "valid.refresh.token";
+            UserId userId = new UserId(1L);
+            String hashedToken = AuthService.hashToken(validToken);
+
+            given(jwtTokenProvider.validateToken(validToken)).willReturn(true);
+            given(jwtTokenProvider.getUserId(validToken)).willReturn(userId.longValue());
+
+            UserRefreshToken storedToken = UserRefreshToken.create(
+                    userId, hashedToken, LocalDateTime.now().plusDays(7));
+            given(userRefreshTokenRepository.findByUserId(userId)).willReturn(Optional.of(storedToken));
+
+            Authentication auth = new UsernamePasswordAuthenticationToken(
+                    String.valueOf(userId), null,
+                    Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER")));
+            given(jwtTokenProvider.getAuthentication(validToken)).willReturn(auth);
+
+            given(jwtTokenProvider.createAccessToken(eq(userId.longValue()), eq("ROLE_USER")))
+                    .willReturn("new.access.token");
+            given(jwtTokenProvider.createRefreshToken(eq(userId.longValue()), eq("ROLE_USER")))
+                    .willReturn("new.refresh.token");
+
+            // when
+            TokenResponse response = authService.refresh(new RefreshTokenRequest(validToken));
+
+            // then
+            assertThat(response.accessToken()).isEqualTo("new.access.token");
+            assertThat(response.refreshToken()).isEqualTo("new.refresh.token");
+
+            // RefreshTokenService.rotateRefreshToken을 통해 새로운 토큰 생성이 위임되었는지 확인
+            verify(refreshTokenService).rotateRefreshToken(userId, "new.refresh.token");
+        }
+
+        @Test
+        @DisplayName("만료된 Refresh Token 요청 시, 해당 사용자의 모든 세션을 무효화하고 예외를 발생시킨다")
+        void refresh_ExpiredToken_InvalidatesAllSessions() {
+            // given
+            String expiredToken = "expired.refresh.token";
+            UserId userId = new UserId(1L);
+
+            given(jwtTokenProvider.validateToken(expiredToken)).willReturn(false);
+            given(jwtTokenProvider.getUserIdFromExpiredToken(expiredToken)).willReturn(userId.longValue());
+
+            // when & then
+            assertThatThrownBy(() -> authService.refresh(new RefreshTokenRequest(expiredToken)))
+                    .isInstanceOf(DomainException.class)
+                    .satisfies(ex -> {
+                        DomainException domainEx = (DomainException) ex;
+                        assertThat(domainEx.getErrorCode()).isEqualTo(ErrorCode.REFRESH_TOKEN_REUSE_DETECTED);
+                    });
+
+            // 전체 세션 무효화 확인
+            then(userRefreshTokenRepository).should().deleteByUserId(userId);
+        }
+
+        @Test
+        @DisplayName("이미 교체된(재사용된) Refresh Token 요청 시, 전체 세션을 무효화하고 예외를 발생시킨다")
+        void refresh_ReusedToken_InvalidatesAllSessions() {
+            // given
+            String reusedToken = "reused.refresh.token";
+            UserId userId = new UserId(1L);
+
+            given(jwtTokenProvider.validateToken(reusedToken)).willReturn(true);
+            given(jwtTokenProvider.getUserId(reusedToken)).willReturn(userId.longValue());
+
+            // DB에는 다른 해시값이 저장되어 있음 (이미 RTR로 교체된 상태)
+            String differentHash = AuthService.hashToken("different.token");
+            UserRefreshToken storedToken = UserRefreshToken.create(
+                    userId, differentHash, LocalDateTime.now().plusDays(7));
+            given(userRefreshTokenRepository.findByUserId(userId)).willReturn(Optional.of(storedToken));
+
+            // when & then
+            assertThatThrownBy(() -> authService.refresh(new RefreshTokenRequest(reusedToken)))
+                    .isInstanceOf(DomainException.class)
+                    .satisfies(ex -> {
+                        DomainException domainEx = (DomainException) ex;
+                        assertThat(domainEx.getErrorCode()).isEqualTo(ErrorCode.REFRESH_TOKEN_REUSE_DETECTED);
+                    });
+
+            then(userRefreshTokenRepository).should().deleteByUserId(userId);
+        }
+
+        @Test
+        @DisplayName("DB에 Refresh Token이 존재하지 않으면 예외를 발생시킨다")
+        void refresh_NotFoundInDb() {
+            // given
+            String validToken = "valid.refresh.token";
+            UserId userId = new UserId(1L);
+
+            given(jwtTokenProvider.validateToken(validToken)).willReturn(true);
+            given(jwtTokenProvider.getUserId(validToken)).willReturn(userId.longValue());
+            given(userRefreshTokenRepository.findByUserId(userId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> authService.refresh(new RefreshTokenRequest(validToken)))
+                    .isInstanceOf(DomainException.class)
+                    .satisfies(ex -> {
+                        DomainException domainEx = (DomainException) ex;
+                        assertThat(domainEx.getErrorCode()).isEqualTo(ErrorCode.REFRESH_TOKEN_NOT_FOUND);
+                    });
+        }
+
+        @Test
+        @DisplayName("DB의 Refresh Token이 만료된 경우, 세션을 무효화하고 예외를 발생시킨다")
+        void refresh_StoredTokenExpired_Deletes() {
+            // given
+            String validToken = "valid.refresh.token";
+            UserId userId = new UserId(1L);
+            String hashedToken = AuthService.hashToken(validToken);
+
+            given(jwtTokenProvider.validateToken(validToken)).willReturn(true);
+            given(jwtTokenProvider.getUserId(validToken)).willReturn(userId.longValue());
+
+            // DB에 만료된 토큰이 저장된 상태
+            UserRefreshToken expiredStoredToken = UserRefreshToken.create(
+                    userId, hashedToken, LocalDateTime.now().minusDays(1));
+            given(userRefreshTokenRepository.findByUserId(userId)).willReturn(Optional.of(expiredStoredToken));
+
+            // when & then
+            assertThatThrownBy(() -> authService.refresh(new RefreshTokenRequest(validToken)))
+                    .isInstanceOf(DomainException.class)
+                    .satisfies(ex -> {
+                        DomainException domainEx = (DomainException) ex;
+                        assertThat(domainEx.getErrorCode()).isEqualTo(ErrorCode.REFRESH_TOKEN_EXPIRED);
+                    });
+
+            then(userRefreshTokenRepository).should().deleteByUserId(userId);
+        }
+    }
+
+    @Nested
+    @DisplayName("SHA-256 해싱")
+    class HashToken {
+
+        @Test
+        @DisplayName("동일한 토큰 입력 시 항상 동일한 해시값을 반환한다")
+        void hashToken_Deterministic() {
+            String token = "test.token.value";
+            String hash1 = AuthService.hashToken(token);
+            String hash2 = AuthService.hashToken(token);
+
+            assertThat(hash1).isEqualTo(hash2);
+        }
+
+        @Test
+        @DisplayName("다른 토큰 입력 시 다른 해시값을 반환한다")
+        void hashToken_DifferentInputs() {
+            String hash1 = AuthService.hashToken("token1");
+            String hash2 = AuthService.hashToken("token2");
+
+            assertThat(hash1).isNotEqualTo(hash2);
+        }
+
+        @Test
+        @DisplayName("해시값은 64자의 16진수 문자열이다 (SHA-256)")
+        void hashToken_Format() {
+            String hash = AuthService.hashToken("test.token");
+
+            assertThat(hash).hasSize(64);
+            assertThat(hash).matches("[0-9a-f]+");
+        }
+    }
+}

--- a/src/test/java/com/personal/interview/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/personal/interview/domain/user/controller/UserControllerTest.java
@@ -20,13 +20,13 @@ import com.personal.interview.domain.user.controller.dto.SignUpRequest;
 import com.personal.interview.domain.user.controller.dto.SignUpResponse;
 import com.personal.interview.domain.user.service.UserService;
 import com.personal.interview.global.config.SecurityConfig;
+import com.personal.interview.util.validator.SecurityValidatorUtil;
 
 import tools.jackson.databind.ObjectMapper;
 
 @WebMvcTest(UserController.class)
 @Import(SecurityConfig.class)
 class UserControllerTest {
-
     @Autowired
     private MockMvc mockMvc;
 
@@ -35,6 +35,24 @@ class UserControllerTest {
 
     @MockitoBean
     private UserService userService;
+
+    @MockitoBean
+    private com.personal.interview.global.security.JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private com.personal.interview.domain.auth.repository.UserRefreshTokenRepository userRefreshTokenRepository;
+
+    @MockitoBean
+    private com.personal.interview.global.security.handler.JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    @MockitoBean
+    private com.personal.interview.global.security.handler.JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
+    @MockitoBean
+    private SecurityValidatorUtil securityValidatorUtil;
+
+    @MockitoBean
+    private com.personal.interview.global.security.service.RefreshTokenService refreshTokenService;
 
     @Test
     void signUp_Success() throws Exception {
@@ -49,8 +67,8 @@ class UserControllerTest {
                 .with(csrf())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
-            .andDo(print())
-            .andExpect(status().isOk());
+                .andDo(print())
+                .andExpect(status().isOk());
     }
 
     @Test

--- a/src/test/java/com/personal/interview/global/security/AuthSecurityIntegrationTest.java
+++ b/src/test/java/com/personal/interview/global/security/AuthSecurityIntegrationTest.java
@@ -30,7 +30,6 @@ import com.personal.interview.domain.user.entity.UserId;
 import com.personal.interview.domain.auth.service.AuthService;
 import com.personal.interview.domain.auth.service.EmailVerifySender;
 import com.personal.interview.domain.user.entity.User;
-import com.personal.interview.domain.user.controller.dto.SignUpRequest;
 import com.personal.interview.domain.user.repository.UserRepository;
 import com.personal.interview.domain.user.UserFixture;
 import com.personal.interview.global.config.properties.JwtProperties;
@@ -115,8 +114,9 @@ class AuthSecurityIntegrationTest {
                         JsonNode json = objectMapper.readTree(responseBody);
                         String rawRefreshToken = json.get("refreshToken").asText();
 
-                        // DB 저장값은 해싱된 값이어야 한다
-                        assertThat(stored.getRefreshToken()).isEqualTo(AuthService.hashToken(rawRefreshToken));
+                        // DB 저장값은 SALT로 해싱된 값이어야 한다
+                        assertThat(stored.getRefreshToken()).isEqualTo(
+                                        AuthService.hashToken(rawRefreshToken, stored.getSalt()));
                 }
 
                 @Test
@@ -196,7 +196,7 @@ class AuthSecurityIntegrationTest {
                 void accessProtectedResource_ExpiredToken() throws Exception {
                         JwtProperties expiredProps = new JwtProperties(
                                         "myDefaultSecretKeyForDevelopmentPurposeOnly12345678901234567890",
-                                        -1L, -1L);
+                                        -1L, -1L, 10L);
                         JwtTokenProvider expiredProvider = new JwtTokenProvider(expiredProps);
                         String expiredToken = expiredProvider.createAccessToken(
                                         testUser.getId().longValue(), testUser.getRole().name());
@@ -219,10 +219,11 @@ class AuthSecurityIntegrationTest {
                         Long userId = testUser.getId().longValue();
                         String role = testUser.getRole().name();
 
-                        // 기존 Refresh Token 발급 및 DB 저장 (해싱)
+                        // 기존 Refresh Token 발급 및 DB 저장 (SALT + 해싱)
                         String originalRefreshToken = jwtTokenProvider.createRefreshToken(userId, role);
-                        String hashedToken = AuthService.hashToken(originalRefreshToken);
-                        UserRefreshToken stored = UserRefreshToken.create(new UserId(userId), hashedToken,
+                        String salt = AuthService.generateSalt();
+                        String hashedToken = AuthService.hashToken(originalRefreshToken, salt);
+                        UserRefreshToken stored = UserRefreshToken.create(new UserId(userId), hashedToken, salt,
                                         LocalDateTime.now().plusDays(7));
 
                         userRefreshTokenRepository.save(stored);
@@ -248,11 +249,12 @@ class AuthSecurityIntegrationTest {
                         JsonNode json = objectMapper.readTree(responseBody);
                         String newRefreshToken = json.get("refreshToken").asText();
 
-                        // DB에 새 해싱된 토큰이 저장되었는지 확인
+                        // DB에 새 해싱된 토큰이 저장되었는지 확인 (새 salt로 해싱됨)
                         UserRefreshToken updated = userRefreshTokenRepository
                                         .findByUserId(new UserId(userId))
                                         .orElseThrow();
-                        assertThat(updated.getRefreshToken()).isEqualTo(AuthService.hashToken(newRefreshToken));
+                        assertThat(updated.getRefreshToken()).isEqualTo(
+                                        AuthService.hashToken(newRefreshToken, updated.getSalt()));
                 }
 
                 @Test
@@ -267,16 +269,21 @@ class AuthSecurityIntegrationTest {
                         // old 토큰은 다른 만료시간을 가진 Provider로 생성하여 서로 다른 값을 보장한다.
                         JwtProperties altProps = new JwtProperties(
                                         "myDefaultSecretKeyForDevelopmentPurposeOnly12345678901234567890",
-                                        3600000L, 86400000L); // 1일 만료 (기본값 7일과 다르므로 다른 JWT 생성)
+                                        3600000L, 86400000L, 10L); // 1일 만료 (기본값 7일과 다르므로 다른 JWT 생성)
                         JwtTokenProvider altProvider = new JwtTokenProvider(altProps);
                         String oldRefreshToken = altProvider.createRefreshToken(userId, role);
                         String newRefreshToken = jwtTokenProvider.createRefreshToken(userId, role);
 
-                        // DB에는 새 토큰의 해시가 저장된 상태
-                        UserRefreshToken stored = UserRefreshToken.create(new UserId(userId),
-                                        AuthService.hashToken(newRefreshToken),
+                        // DB에는 새 토큰의 해시가 저장된 상태 (Grace Period 지난 후)
+                        String salt = AuthService.generateSalt();
+                        UserRefreshToken stored2 = UserRefreshToken.create(new UserId(userId),
+                                        AuthService.hashToken(newRefreshToken, salt), salt,
                                         LocalDateTime.now().plusDays(7));
-                        userRefreshTokenRepository.save(stored);
+                        // Grace Period 밖이어야 재사용이 탈취로 감지되므로 rotatedAt을 과거로 설정
+                        java.lang.reflect.Field createdAtField = UserRefreshToken.class.getDeclaredField("createdAt");
+                        createdAtField.setAccessible(true);
+                        createdAtField.set(stored2, LocalDateTime.now().minusMinutes(5));
+                        userRefreshTokenRepository.save(stored2);
                         em.flush();
                         em.clear();
 
@@ -307,15 +314,16 @@ class AuthSecurityIntegrationTest {
                         // 만료된 Refresh Token 생성
                         JwtProperties expiredProps = new JwtProperties(
                                         "myDefaultSecretKeyForDevelopmentPurposeOnly12345678901234567890",
-                                        -1L, -1L);
+                                        -1L, -1L, 10L);
                         JwtTokenProvider expiredProvider = new JwtTokenProvider(expiredProps);
                         String expiredRefreshToken = expiredProvider.createRefreshToken(userId, role);
 
                         // DB에 토큰 저장 (만료 감지 전 상태)
-                        UserRefreshToken stored = UserRefreshToken.create(new UserId(userId),
-                                        AuthService.hashToken(expiredRefreshToken),
+                        String salt = AuthService.generateSalt();
+                        UserRefreshToken stored3 = UserRefreshToken.create(new UserId(userId),
+                                        AuthService.hashToken(expiredRefreshToken, salt), salt,
                                         LocalDateTime.now().plusDays(7));
-                        userRefreshTokenRepository.save(stored);
+                        userRefreshTokenRepository.save(stored3);
                         em.flush();
                         em.clear();
 

--- a/src/test/java/com/personal/interview/global/security/AuthSecurityIntegrationTest.java
+++ b/src/test/java/com/personal/interview/global/security/AuthSecurityIntegrationTest.java
@@ -1,0 +1,361 @@
+package com.personal.interview.global.security;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.JsonNode;
+import com.personal.interview.domain.auth.entity.UserRefreshToken;
+import com.personal.interview.domain.auth.repository.UserRefreshTokenRepository;
+import com.personal.interview.domain.user.entity.UserId;
+import com.personal.interview.domain.auth.service.AuthService;
+import com.personal.interview.domain.auth.service.EmailVerifySender;
+import com.personal.interview.domain.user.entity.User;
+import com.personal.interview.domain.user.controller.dto.SignUpRequest;
+import com.personal.interview.domain.user.repository.UserRepository;
+import com.personal.interview.domain.user.UserFixture;
+import com.personal.interview.global.config.properties.JwtProperties;
+
+import jakarta.persistence.EntityManager;
+
+/**
+ * Security 필터 체인 통합 테스트.
+ *
+ * 실제 Spring Security Filter Chain을 통해 아래 흐름을 End-to-End로 검증합니다:
+ * - 로그인 (CustomAuthenticationFilter → SuccessHandler / FailureHandler)
+ * - JWT 인증 (JwtAuthenticationFilter → SecurityContext)
+ * - 인증 실패 (JwtAuthenticationEntryPoint → 401)
+ * - 토큰 재발급 (AuthController → AuthService RTR/해싱)
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class AuthSecurityIntegrationTest {
+
+        @Autowired
+        private MockMvc mockMvc;
+
+        @Autowired
+        private ObjectMapper objectMapper;
+
+        @Autowired
+        private UserRepository userRepository;
+
+        @Autowired
+        private UserRefreshTokenRepository userRefreshTokenRepository;
+
+        @Autowired
+        private PasswordEncoder passwordEncoder;
+
+        @Autowired
+        private JwtTokenProvider jwtTokenProvider;
+
+        @Autowired
+        private EntityManager em;
+
+        @MockitoBean
+        private EmailVerifySender emailVerifySender;
+
+        private User testUser;
+
+        @BeforeEach
+        void setUp() {
+                // 테스트 사용자 생성
+                testUser = UserFixture.createDefaultUser(passwordEncoder);
+                userRepository.save(testUser);
+                em.flush();
+                em.clear();
+        }
+
+        @Nested
+        @DisplayName("로그인 (POST /api/auth/login)")
+        class Login {
+
+                @Test
+                @DisplayName("올바른 이메일/비밀번호로 로그인하면 200 OK와 Access/Refresh Token을 반환한다")
+                void login_Success() throws Exception {
+                        String loginJson = """
+                                        {"email": "%s", "password": "%s"}
+                                        """.formatted(UserFixture.DEFAULT_EMAIL, UserFixture.DEFAULT_RAW_PASSWORD);
+
+                        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                                        .contentType(MediaType.APPLICATION_JSON)
+                                        .content(loginJson))
+                                        .andDo(print())
+                                        .andExpect(status().isOk())
+                                        .andExpect(jsonPath("$.accessToken").isNotEmpty())
+                                        .andExpect(jsonPath("$.refreshToken").isNotEmpty())
+                                        .andReturn();
+
+                        UserRefreshToken stored = userRefreshTokenRepository
+                                        .findByUserId(new UserId(testUser.getId().longValue()))
+                                        .orElseThrow();
+
+                        String responseBody = result.getResponse().getContentAsString();
+                        JsonNode json = objectMapper.readTree(responseBody);
+                        String rawRefreshToken = json.get("refreshToken").asText();
+
+                        // DB 저장값은 해싱된 값이어야 한다
+                        assertThat(stored.getRefreshToken()).isEqualTo(AuthService.hashToken(rawRefreshToken));
+                }
+
+                @Test
+                @DisplayName("잘못된 비밀번호로 로그인하면 401과 INVALID_CREDENTIALS를 반환한다")
+                void login_WrongPassword() throws Exception {
+                        String loginJson = """
+                                        {"email": "%s", "password": "wrongPassword"}
+                                        """.formatted(UserFixture.DEFAULT_EMAIL);
+
+                        mockMvc.perform(post("/api/auth/login")
+                                        .contentType(MediaType.APPLICATION_JSON)
+                                        .content(loginJson))
+                                        .andDo(print())
+                                        .andExpect(status().isUnauthorized())
+                                        .andExpect(jsonPath("$.code").value("AUTH_005"))
+                                        .andExpect(jsonPath("$.message").value("이메일 또는 비밀번호가 올바르지 않습니다."));
+                }
+
+                @Test
+                @DisplayName("존재하지 않는 이메일로 로그인하면 401과 동일한 Generic 에러 메시지를 반환한다")
+                void login_UserNotFound_GenericError() throws Exception {
+                        String loginJson = """
+                                        {"email": "nonexistent@example.com", "password": "password"}
+                                        """;
+
+                        mockMvc.perform(post("/api/auth/login")
+                                        .contentType(MediaType.APPLICATION_JSON)
+                                        .content(loginJson))
+                                        .andDo(print())
+                                        .andExpect(status().isUnauthorized())
+                                        .andExpect(jsonPath("$.code").value("AUTH_005"));
+                }
+        }
+
+        @Nested
+        @DisplayName("JWT 인증 (보호된 리소스 접근)")
+        class JwtAuthentication {
+
+                @Test
+                @DisplayName("유효한 Access Token으로 보호된 API에 접근하면 인증이 성공한다")
+                void accessProtectedResource_WithValidToken() throws Exception {
+                        String accessToken = jwtTokenProvider.createAccessToken(
+                                        testUser.getId().longValue(), testUser.getRole().name());
+
+                        // 보호된 리소스에 접근 — 인증은 통과하므로 401/403이 아닌 다른 상태코드가 반환되어야 함
+                        mockMvc.perform(get("/api/protected/resource")
+                                        .header("Authorization", "Bearer " + accessToken))
+                                        .andDo(print())
+                                        .andExpect(result -> {
+                                                int status = result.getResponse().getStatus();
+                                                assertThat(status).isNotEqualTo(401);
+                                                assertThat(status).isNotEqualTo(403);
+                                        });
+                }
+
+                @Test
+                @DisplayName("토큰 없이 보호된 API에 접근하면 401 INVALID_TOKEN을 반환한다")
+                void accessProtectedResource_NoToken() throws Exception {
+                        mockMvc.perform(get("/api/protected/resource"))
+                                        .andDo(print())
+                                        .andExpect(status().isUnauthorized())
+                                        .andExpect(jsonPath("$.code").value("AUTH_004"));
+                }
+
+                @Test
+                @DisplayName("위변조된 토큰으로 접근하면 401 INVALID_TOKEN을 반환한다")
+                void accessProtectedResource_TamperedToken() throws Exception {
+                        mockMvc.perform(get("/api/protected/resource")
+                                        .header("Authorization", "Bearer invalid.token.here"))
+                                        .andDo(print())
+                                        .andExpect(status().isUnauthorized())
+                                        .andExpect(jsonPath("$.code").value("AUTH_004"));
+                }
+
+                @Test
+                @DisplayName("만료된 토큰으로 접근하면 401 INVALID_TOKEN을 반환한다")
+                void accessProtectedResource_ExpiredToken() throws Exception {
+                        JwtProperties expiredProps = new JwtProperties(
+                                        "myDefaultSecretKeyForDevelopmentPurposeOnly12345678901234567890",
+                                        -1L, -1L);
+                        JwtTokenProvider expiredProvider = new JwtTokenProvider(expiredProps);
+                        String expiredToken = expiredProvider.createAccessToken(
+                                        testUser.getId().longValue(), testUser.getRole().name());
+
+                        mockMvc.perform(get("/api/protected/resource")
+                                        .header("Authorization", "Bearer " + expiredToken))
+                                        .andDo(print())
+                                        .andExpect(status().isUnauthorized())
+                                        .andExpect(jsonPath("$.code").value("AUTH_004"));
+                }
+        }
+
+        @Nested
+        @DisplayName("토큰 재발급 (POST /api/auth/refresh)")
+        class RefreshToken {
+
+                @Test
+                @DisplayName("유효한 Refresh Token으로 재발급하면 새로운 토큰 쌍을 반환한다 (RTR)")
+                void refresh_Success() throws Exception {
+                        Long userId = testUser.getId().longValue();
+                        String role = testUser.getRole().name();
+
+                        // 기존 Refresh Token 발급 및 DB 저장 (해싱)
+                        String originalRefreshToken = jwtTokenProvider.createRefreshToken(userId, role);
+                        String hashedToken = AuthService.hashToken(originalRefreshToken);
+                        UserRefreshToken stored = UserRefreshToken.create(new UserId(userId), hashedToken,
+                                        LocalDateTime.now().plusDays(7));
+
+                        userRefreshTokenRepository.save(stored);
+                        em.flush();
+                        em.clear();
+
+                        // 재발급 요청
+                        String requestJson = """
+                                        {"refreshToken": "%s"}
+                                        """.formatted(originalRefreshToken);
+
+                        MvcResult result = mockMvc.perform(post("/api/auth/refresh")
+                                        .contentType(MediaType.APPLICATION_JSON)
+                                        .content(requestJson))
+                                        .andDo(print())
+                                        .andExpect(status().isOk())
+                                        .andExpect(jsonPath("$.accessToken").isNotEmpty())
+                                        .andExpect(jsonPath("$.refreshToken").isNotEmpty())
+                                        .andReturn();
+
+                        // 응답의 새 토큰 추출
+                        String responseBody = result.getResponse().getContentAsString();
+                        JsonNode json = objectMapper.readTree(responseBody);
+                        String newRefreshToken = json.get("refreshToken").asText();
+
+                        // DB에 새 해싱된 토큰이 저장되었는지 확인
+                        UserRefreshToken updated = userRefreshTokenRepository
+                                        .findByUserId(new UserId(userId))
+                                        .orElseThrow();
+                        assertThat(updated.getRefreshToken()).isEqualTo(AuthService.hashToken(newRefreshToken));
+                }
+
+                @Test
+                @DisplayName("이미 교체된(재사용된) Refresh Token으로 재발급하면 401이고 전체 세션이 무효화된다")
+                void refresh_ReusedToken_InvalidatesAllSessions() throws Exception {
+                        Long userId = testUser.getId().longValue();
+                        String role = testUser.getRole().name();
+
+                        // 이미 교체된 상태 시뮬레이션:
+                        // DB에는 새로운 해시가 저장되었는데, 클라이언트는 이전 토큰으로 요청
+                        // 주의: 같은 초에 동일한 claims로 JWT를 생성하면 동일한 문자열이 되므로,
+                        // old 토큰은 다른 만료시간을 가진 Provider로 생성하여 서로 다른 값을 보장한다.
+                        JwtProperties altProps = new JwtProperties(
+                                        "myDefaultSecretKeyForDevelopmentPurposeOnly12345678901234567890",
+                                        3600000L, 86400000L); // 1일 만료 (기본값 7일과 다르므로 다른 JWT 생성)
+                        JwtTokenProvider altProvider = new JwtTokenProvider(altProps);
+                        String oldRefreshToken = altProvider.createRefreshToken(userId, role);
+                        String newRefreshToken = jwtTokenProvider.createRefreshToken(userId, role);
+
+                        // DB에는 새 토큰의 해시가 저장된 상태
+                        UserRefreshToken stored = UserRefreshToken.create(new UserId(userId),
+                                        AuthService.hashToken(newRefreshToken),
+                                        LocalDateTime.now().plusDays(7));
+                        userRefreshTokenRepository.save(stored);
+                        em.flush();
+                        em.clear();
+
+                        // 이전(old) 토큰으로 재발급 요청 → 탈취 간주
+                        String requestJson = """
+                                        {"refreshToken": "%s"}
+                                        """.formatted(oldRefreshToken);
+
+                        mockMvc.perform(post("/api/auth/refresh")
+                                        .contentType(MediaType.APPLICATION_JSON)
+                                        .content(requestJson))
+                                        .andDo(print())
+                                        .andExpect(status().isUnauthorized())
+                                        .andExpect(jsonPath("$.code").value("AUTH_009"));
+                        em.flush();
+                        em.clear();
+
+                        // 전체 세션 무효화 확인 (DB에서 삭제됨)
+                        assertThat(userRefreshTokenRepository.findByUserId(new UserId(userId))).isEmpty();
+                }
+
+                @Test
+                @DisplayName("만료된 Refresh Token으로 재발급하면 401이고 전체 세션이 무효화된다")
+                void refresh_ExpiredToken_InvalidatesAllSessions() throws Exception {
+                        Long userId = testUser.getId().longValue();
+                        String role = testUser.getRole().name();
+
+                        // 만료된 Refresh Token 생성
+                        JwtProperties expiredProps = new JwtProperties(
+                                        "myDefaultSecretKeyForDevelopmentPurposeOnly12345678901234567890",
+                                        -1L, -1L);
+                        JwtTokenProvider expiredProvider = new JwtTokenProvider(expiredProps);
+                        String expiredRefreshToken = expiredProvider.createRefreshToken(userId, role);
+
+                        // DB에 토큰 저장 (만료 감지 전 상태)
+                        UserRefreshToken stored = UserRefreshToken.create(new UserId(userId),
+                                        AuthService.hashToken(expiredRefreshToken),
+                                        LocalDateTime.now().plusDays(7));
+                        userRefreshTokenRepository.save(stored);
+                        em.flush();
+                        em.clear();
+
+                        String requestJson = """
+                                        {"refreshToken": "%s"}
+                                        """.formatted(expiredRefreshToken);
+
+                        mockMvc.perform(post("/api/auth/refresh")
+                                        .contentType(MediaType.APPLICATION_JSON)
+                                        .content(requestJson))
+                                        .andDo(print())
+                                        .andExpect(status().isUnauthorized())
+                                        .andExpect(jsonPath("$.code").value("AUTH_009"));
+
+                        // 전체 세션 무효화 확인
+                        assertThat(userRefreshTokenRepository.findByUserId(new UserId(userId))).isEmpty();
+                }
+        }
+
+        @Nested
+        @DisplayName("공개 엔드포인트 접근")
+        class PublicEndpoints {
+
+                @Test
+                @DisplayName("회원가입 API는 인증 없이 접근 가능하다")
+                void signUp_NoAuthRequired() throws Exception {
+                        String signUpJson = """
+                                        {
+                                            "email": "newuser@example.com",
+                                            "password": "password123",
+                                            "nickname": "신규유저",
+                                            "jobCategoryNames": ["BACKEND"]
+                                        }
+                                        """;
+
+                        mockMvc.perform(post("/api/user/signup")
+                                        .contentType(MediaType.APPLICATION_JSON)
+                                        .content(signUpJson))
+                                        .andDo(print())
+                                        .andExpect(status().isOk());
+                }
+        }
+}

--- a/src/test/java/com/personal/interview/global/security/JwtTokenProviderTest.java
+++ b/src/test/java/com/personal/interview/global/security/JwtTokenProviderTest.java
@@ -20,7 +20,7 @@ class JwtTokenProviderTest {
 
     @BeforeEach
     void setUp() {
-        JwtProperties jwtProperties = new JwtProperties(SECRET_KEY, ACCESS_EXPIRATION_MS, REFRESH_EXPIRATION_MS);
+        JwtProperties jwtProperties = new JwtProperties(SECRET_KEY, ACCESS_EXPIRATION_MS, REFRESH_EXPIRATION_MS, 10L);
         jwtTokenProvider = new JwtTokenProvider(jwtProperties);
     }
 
@@ -72,7 +72,7 @@ class JwtTokenProviderTest {
         @DisplayName("만료된 토큰은 검증에 실패한다")
         void validateToken_Expired() {
             // 만료 시간이 -1ms인 토큰 생성용 Provider
-            JwtProperties expiredProps = new JwtProperties(SECRET_KEY, -1L, -1L);
+            JwtProperties expiredProps = new JwtProperties(SECRET_KEY, -1L, -1L, 10L);
             JwtTokenProvider expiredProvider = new JwtTokenProvider(expiredProps);
 
             String expiredToken = expiredProvider.createAccessToken(1L, "ROLE_USER");
@@ -97,7 +97,7 @@ class JwtTokenProviderTest {
         void validateToken_DifferentKey() {
             JwtProperties otherProps = new JwtProperties(
                     "anotherSecretKeyThatIsDifferentFromOriginal12345678901234567890",
-                    ACCESS_EXPIRATION_MS, REFRESH_EXPIRATION_MS);
+                    ACCESS_EXPIRATION_MS, REFRESH_EXPIRATION_MS, 10L);
             JwtTokenProvider otherProvider = new JwtTokenProvider(otherProps);
 
             String tokenFromOtherKey = otherProvider.createAccessToken(1L, "ROLE_USER");
@@ -140,7 +140,7 @@ class JwtTokenProviderTest {
         void getUserIdFromExpiredToken() {
             Long expectedUserId = 99L;
 
-            JwtProperties expiredProps = new JwtProperties(SECRET_KEY, -1L, -1L);
+            JwtProperties expiredProps = new JwtProperties(SECRET_KEY, -1L, -1L, 10L);
             JwtTokenProvider expiredProvider = new JwtTokenProvider(expiredProps);
             String expiredToken = expiredProvider.createAccessToken(expectedUserId, "ROLE_USER");
 

--- a/src/test/java/com/personal/interview/global/security/JwtTokenProviderTest.java
+++ b/src/test/java/com/personal/interview/global/security/JwtTokenProviderTest.java
@@ -1,0 +1,164 @@
+package com.personal.interview.global.security;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.Authentication;
+
+import com.personal.interview.global.config.properties.JwtProperties;
+
+class JwtTokenProviderTest {
+
+    private JwtTokenProvider jwtTokenProvider;
+
+    private static final String SECRET_KEY = "myTestSecretKeyForJwtUnitTestPurposeOnly12345678901234567890";
+    private static final long ACCESS_EXPIRATION_MS = 1800000L; // 30분
+    private static final long REFRESH_EXPIRATION_MS = 604800000L; // 7일
+
+    @BeforeEach
+    void setUp() {
+        JwtProperties jwtProperties = new JwtProperties(SECRET_KEY, ACCESS_EXPIRATION_MS, REFRESH_EXPIRATION_MS);
+        jwtTokenProvider = new JwtTokenProvider(jwtProperties);
+    }
+
+    @Nested
+    @DisplayName("토큰 생성")
+    class CreateToken {
+
+        @Test
+        @DisplayName("Access Token을 생성하면 유효한 JWT 문자열을 반환한다")
+        void createAccessToken() {
+            String token = jwtTokenProvider.createAccessToken(1L, "ROLE_USER");
+
+            assertThat(token).isNotBlank();
+            assertThat(token.split("\\.")).hasSize(3); // header.payload.signature
+        }
+
+        @Test
+        @DisplayName("Refresh Token을 생성하면 유효한 JWT 문자열을 반환한다")
+        void createRefreshToken() {
+            String token = jwtTokenProvider.createRefreshToken(1L, "ROLE_USER");
+
+            assertThat(token).isNotBlank();
+            assertThat(token.split("\\.")).hasSize(3);
+        }
+    }
+
+    @Nested
+    @DisplayName("토큰 검증")
+    class ValidateToken {
+
+        @Test
+        @DisplayName("정상 토큰은 검증에 성공한다")
+        void validateToken_Success() {
+            String token = jwtTokenProvider.createAccessToken(1L, "ROLE_USER");
+
+            assertThat(jwtTokenProvider.validateToken(token)).isTrue();
+        }
+
+        @Test
+        @DisplayName("위변조된 토큰은 검증에 실패한다")
+        void validateToken_Tampered() {
+            String token = jwtTokenProvider.createAccessToken(1L, "ROLE_USER");
+            String tamperedToken = token + "tampered";
+
+            assertThat(jwtTokenProvider.validateToken(tamperedToken)).isFalse();
+        }
+
+        @Test
+        @DisplayName("만료된 토큰은 검증에 실패한다")
+        void validateToken_Expired() {
+            // 만료 시간이 -1ms인 토큰 생성용 Provider
+            JwtProperties expiredProps = new JwtProperties(SECRET_KEY, -1L, -1L);
+            JwtTokenProvider expiredProvider = new JwtTokenProvider(expiredProps);
+
+            String expiredToken = expiredProvider.createAccessToken(1L, "ROLE_USER");
+
+            assertThat(jwtTokenProvider.validateToken(expiredToken)).isFalse();
+        }
+
+        @Test
+        @DisplayName("null 토큰은 검증에 실패한다")
+        void validateToken_Null() {
+            assertThat(jwtTokenProvider.validateToken(null)).isFalse();
+        }
+
+        @Test
+        @DisplayName("빈 문자열 토큰은 검증에 실패한다")
+        void validateToken_Empty() {
+            assertThat(jwtTokenProvider.validateToken("")).isFalse();
+        }
+
+        @Test
+        @DisplayName("다른 Secret Key로 생성된 토큰은 검증에 실패한다")
+        void validateToken_DifferentKey() {
+            JwtProperties otherProps = new JwtProperties(
+                    "anotherSecretKeyThatIsDifferentFromOriginal12345678901234567890",
+                    ACCESS_EXPIRATION_MS, REFRESH_EXPIRATION_MS);
+            JwtTokenProvider otherProvider = new JwtTokenProvider(otherProps);
+
+            String tokenFromOtherKey = otherProvider.createAccessToken(1L, "ROLE_USER");
+
+            assertThat(jwtTokenProvider.validateToken(tokenFromOtherKey)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("토큰에서 정보 추출")
+    class ExtractInfo {
+
+        @Test
+        @DisplayName("토큰에서 userId를 추출한다")
+        void getUserId() {
+            Long expectedUserId = 42L;
+            String token = jwtTokenProvider.createAccessToken(expectedUserId, "ROLE_USER");
+
+            Long userId = jwtTokenProvider.getUserId(token);
+
+            assertThat(userId).isEqualTo(expectedUserId);
+        }
+
+        @Test
+        @DisplayName("토큰에서 Authentication 객체를 추출하면 userId와 role이 포함되어 있다")
+        void getAuthentication() {
+            Long expectedUserId = 42L;
+            String expectedRole = "ROLE_ADMIN";
+            String token = jwtTokenProvider.createAccessToken(expectedUserId, expectedRole);
+
+            Authentication auth = jwtTokenProvider.getAuthentication(token);
+
+            assertThat(auth.getName()).isEqualTo(String.valueOf(expectedUserId));
+            assertThat(auth.getAuthorities()).hasSize(1);
+            assertThat(auth.getAuthorities().iterator().next().getAuthority()).isEqualTo(expectedRole);
+        }
+
+        @Test
+        @DisplayName("만료된 토큰에서도 userId를 추출할 수 있다")
+        void getUserIdFromExpiredToken() {
+            Long expectedUserId = 99L;
+
+            JwtProperties expiredProps = new JwtProperties(SECRET_KEY, -1L, -1L);
+            JwtTokenProvider expiredProvider = new JwtTokenProvider(expiredProps);
+            String expiredToken = expiredProvider.createAccessToken(expectedUserId, "ROLE_USER");
+
+            // 만료된 토큰이지만 userId 추출 가능
+            Long userId = jwtTokenProvider.getUserIdFromExpiredToken(expiredToken);
+
+            assertThat(userId).isEqualTo(expectedUserId);
+        }
+    }
+
+    @Nested
+    @DisplayName("만료 시간 설정")
+    class ExpirationConfig {
+
+        @Test
+        @DisplayName("getRefreshExpirationMs는 설정된 값을 반환한다")
+        void getRefreshExpirationMs() {
+            assertThat(jwtTokenProvider.getRefreshExpirationMs()).isEqualTo(REFRESH_EXPIRATION_MS);
+        }
+    }
+}

--- a/src/test/java/com/personal/interview/global/security/aop/AuthorizeAspectTest.java
+++ b/src/test/java/com/personal/interview/global/security/aop/AuthorizeAspectTest.java
@@ -1,0 +1,108 @@
+package com.personal.interview.global.security.aop;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import org.aspectj.lang.JoinPoint;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import com.personal.interview.domain.user.entity.vo.UserRole;
+import com.personal.interview.global.exception.DomainException;
+import com.personal.interview.global.security.annotation.Authorize;
+
+@ExtendWith(MockitoExtension.class)
+class AuthorizeAspectTest {
+
+    @InjectMocks
+    private AuthorizeAspect authorizeAspect;
+
+    @Mock
+    private JoinPoint joinPoint;
+
+    @Mock
+    private Authorize authorize;
+
+    private SecurityContext originalContext;
+
+    @BeforeEach
+    void setUp() {
+        originalContext = SecurityContextHolder.getContext();
+        SecurityContextHolder.setContext(SecurityContextHolder.createEmptyContext());
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.setContext(originalContext);
+    }
+
+    private void setAuthentication(String role) {
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                "principal", "credentials", Collections.singletonList(new SimpleGrantedAuthority(role)));
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    @Test
+    @DisplayName("인증 정보가 없으면 DomainException 이 발생한다")
+    void checkAuthorize_NoAuth() {
+        // given
+        SecurityContextHolder.clearContext();
+
+        // when & then
+        assertThatThrownBy(() -> authorizeAspect.checkAuthorize(joinPoint, authorize))
+            .isInstanceOf(DomainException.class);
+    }
+
+    @Test
+    @DisplayName("Authorize 에 명시된 권한이 빈 배열이면 무조건 통과한다")
+    void checkAuthorize_EmptyRoles() {
+        // given
+        setAuthentication("ROLE_USER");
+        given(authorize.value()).willReturn(new UserRole[] {});
+
+        // when & then
+        assertThatCode(() -> authorizeAspect.checkAuthorize(joinPoint, authorize))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("사용자가 요구된 권한을 가지고 있으면 통과한다")
+    void checkAuthorize_HasRole_Success() {
+        // given
+        setAuthentication("ROLE_DRAFT");
+        given(authorize.value()).willReturn(new UserRole[] { UserRole.ROLE_DRAFT, UserRole.ROLE_USER });
+
+        // when & then
+        assertThatCode(() -> authorizeAspect.checkAuthorize(joinPoint, authorize))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("사용자가 요구된 권한이 전혀 없으면 DomainException 이 발생한다")
+    void checkAuthorize_HasNoRole_Fail() {
+        // given
+        setAuthentication("ROLE_USER");
+        given(authorize.value()).willReturn(new UserRole[] { UserRole.ROLE_DRAFT });
+
+        // when & then
+        assertThatThrownBy(() -> authorizeAspect.checkAuthorize(joinPoint, authorize))
+            .isInstanceOf(DomainException.class);
+    }
+}

--- a/src/test/java/com/personal/interview/global/security/aop/AuthorizeAspectTest.java
+++ b/src/test/java/com/personal/interview/global/security/aop/AuthorizeAspectTest.java
@@ -1,14 +1,14 @@
 package com.personal.interview.global.security.aop;
 
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.*;
 
+import java.lang.reflect.Method;
 import java.util.Collections;
 
 import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -38,7 +37,7 @@ class AuthorizeAspectTest {
     private JoinPoint joinPoint;
 
     @Mock
-    private Authorize authorize;
+    private MethodSignature methodSignature;
 
     private SecurityContext originalContext;
 
@@ -59,50 +58,88 @@ class AuthorizeAspectTest {
         SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 
+    // ── 테스트용 @Authorize 스텁 ──
+
+    @Authorize(UserRole.ROLE_DRAFT)
+    static class ClassLevelAuthorized {
+        public void someMethod() {
+        }
+    }
+
+    static class MethodLevelAuthorized {
+        @Authorize(UserRole.ROLE_USER)
+        public void protectedMethod() {
+        }
+
+        @Authorize({})
+        public void emptyRoleMethod() {
+        }
+    }
+
+    private void mockJoinPoint(Object target, String methodName) throws NoSuchMethodException {
+        Method method = target.getClass().getDeclaredMethod(methodName);
+        given(joinPoint.getSignature()).willReturn(methodSignature);
+        given(methodSignature.getMethod()).willReturn(method);
+        lenient().when(joinPoint.getTarget()).thenReturn(target);
+    }
+
     @Test
-    @DisplayName("인증 정보가 없으면 DomainException 이 발생한다")
-    void checkAuthorize_NoAuth() {
-        // given
+    @DisplayName("인증 정보가 없으면 DomainException이 발생한다")
+    void checkAuthorize_NoAuth() throws Exception {
         SecurityContextHolder.clearContext();
+        mockJoinPoint(new MethodLevelAuthorized(), "protectedMethod");
 
-        // when & then
-        assertThatThrownBy(() -> authorizeAspect.checkAuthorize(joinPoint, authorize))
-            .isInstanceOf(DomainException.class);
+        assertThatThrownBy(() -> authorizeAspect.checkAuthorize(joinPoint))
+                .isInstanceOf(DomainException.class);
     }
 
     @Test
-    @DisplayName("Authorize 에 명시된 권한이 빈 배열이면 무조건 통과한다")
-    void checkAuthorize_EmptyRoles() {
-        // given
+    @DisplayName("@Authorize에 명시된 권한이 빈 배열이면 무조건 통과한다")
+    void checkAuthorize_EmptyRoles() throws Exception {
         setAuthentication("ROLE_USER");
-        given(authorize.value()).willReturn(new UserRole[] {});
+        mockJoinPoint(new MethodLevelAuthorized(), "emptyRoleMethod");
 
-        // when & then
-        assertThatCode(() -> authorizeAspect.checkAuthorize(joinPoint, authorize))
+        assertThatCode(() -> authorizeAspect.checkAuthorize(joinPoint))
                 .doesNotThrowAnyException();
     }
 
     @Test
-    @DisplayName("사용자가 요구된 권한을 가지고 있으면 통과한다")
-    void checkAuthorize_HasRole_Success() {
-        // given
+    @DisplayName("메서드 레벨 @Authorize: 사용자가 요구 권한을 가지면 통과한다")
+    void checkAuthorize_MethodLevel_HasRole_Success() throws Exception {
+        setAuthentication("ROLE_USER");
+        mockJoinPoint(new MethodLevelAuthorized(), "protectedMethod");
+
+        assertThatCode(() -> authorizeAspect.checkAuthorize(joinPoint))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("메서드 레벨 @Authorize: 사용자가 요구 권한이 없으면 DomainException이 발생한다")
+    void checkAuthorize_MethodLevel_NoRole_Fail() throws Exception {
+        setAuthentication("ROLE_ADMIN");
+        mockJoinPoint(new MethodLevelAuthorized(), "protectedMethod");
+
+        assertThatThrownBy(() -> authorizeAspect.checkAuthorize(joinPoint))
+                .isInstanceOf(DomainException.class);
+    }
+
+    @Test
+    @DisplayName("클래스 레벨 @Authorize: 메서드에 어노테이션이 없으면 클래스 레벨을 사용한다")
+    void checkAuthorize_ClassLevel_Fallback() throws Exception {
         setAuthentication("ROLE_DRAFT");
-        given(authorize.value()).willReturn(new UserRole[] { UserRole.ROLE_DRAFT, UserRole.ROLE_USER });
+        mockJoinPoint(new ClassLevelAuthorized(), "someMethod");
 
-        // when & then
-        assertThatCode(() -> authorizeAspect.checkAuthorize(joinPoint, authorize))
+        assertThatCode(() -> authorizeAspect.checkAuthorize(joinPoint))
                 .doesNotThrowAnyException();
     }
 
     @Test
-    @DisplayName("사용자가 요구된 권한이 전혀 없으면 DomainException 이 발생한다")
-    void checkAuthorize_HasNoRole_Fail() {
-        // given
+    @DisplayName("클래스 레벨 @Authorize: 사용자 권한이 없으면 DomainException이 발생한다")
+    void checkAuthorize_ClassLevel_NoRole_Fail() throws Exception {
         setAuthentication("ROLE_USER");
-        given(authorize.value()).willReturn(new UserRole[] { UserRole.ROLE_DRAFT });
+        mockJoinPoint(new ClassLevelAuthorized(), "someMethod");
 
-        // when & then
-        assertThatThrownBy(() -> authorizeAspect.checkAuthorize(joinPoint, authorize))
-            .isInstanceOf(DomainException.class);
+        assertThatThrownBy(() -> authorizeAspect.checkAuthorize(joinPoint))
+                .isInstanceOf(DomainException.class);
     }
 }

--- a/src/test/java/com/personal/interview/global/security/service/RefreshTokenServiceTest.java
+++ b/src/test/java/com/personal/interview/global/security/service/RefreshTokenServiceTest.java
@@ -2,7 +2,6 @@ package com.personal.interview.global.security.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -20,7 +19,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.personal.interview.domain.auth.entity.UserRefreshToken;
 import com.personal.interview.domain.auth.repository.UserRefreshTokenRepository;
-import com.personal.interview.domain.auth.service.AuthService;
 import com.personal.interview.domain.user.entity.UserId;
 import com.personal.interview.global.security.JwtTokenProvider;
 
@@ -51,9 +49,8 @@ class RefreshTokenServiceTest {
         // when
         refreshTokenService.rotateRefreshToken(userId, refreshToken);
 
-        // then
-        String expectedHashed = AuthService.hashToken(refreshToken);
-        verify(existingToken).updateRefreshToken(eq(expectedHashed), any(LocalDateTime.class));
+        // then - SALT가 포함된 해시값으로 업데이트되었는지 확인
+        verify(existingToken).rotateToken(any(String.class), any(String.class), any(LocalDateTime.class));
     }
 
     @Test
@@ -75,9 +72,10 @@ class RefreshTokenServiceTest {
         verify(userRefreshTokenRepository).save(captor.capture());
 
         UserRefreshToken savedToken = captor.getValue();
-        String expectedHashed = AuthService.hashToken(refreshToken);
 
         assertThat(savedToken).isNotNull();
-        assertThat(savedToken.getRefreshToken()).isEqualTo(expectedHashed);
+        assertThat(savedToken.getRefreshToken()).isNotBlank();
+        assertThat(savedToken.getSalt()).isNotBlank();
+        assertThat(savedToken.getSalt()).hasSize(32); // 16바이트 hex = 32자
     }
 }

--- a/src/test/java/com/personal/interview/global/security/service/RefreshTokenServiceTest.java
+++ b/src/test/java/com/personal/interview/global/security/service/RefreshTokenServiceTest.java
@@ -1,0 +1,83 @@
+package com.personal.interview.global.security.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.personal.interview.domain.auth.entity.UserRefreshToken;
+import com.personal.interview.domain.auth.repository.UserRefreshTokenRepository;
+import com.personal.interview.domain.auth.service.AuthService;
+import com.personal.interview.domain.user.entity.UserId;
+import com.personal.interview.global.security.JwtTokenProvider;
+
+@ExtendWith(MockitoExtension.class)
+class RefreshTokenServiceTest {
+
+    @Mock
+    private UserRefreshTokenRepository userRefreshTokenRepository;
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @InjectMocks
+    private RefreshTokenService refreshTokenService;
+
+    @Test
+    @DisplayName("DB에 존재하면 기존 토큰 엔티티를 업데이트한다")
+    void rotateRefreshToken_UpdatesExisting() {
+        // given
+        UserId userId = new UserId(1L);
+        String refreshToken = "refreshTokenString";
+        long expirationMs = 1000000L;
+
+        given(jwtTokenProvider.getRefreshExpirationMs()).willReturn(expirationMs);
+        UserRefreshToken existingToken = mock(UserRefreshToken.class);
+        given(userRefreshTokenRepository.findByUserId(userId)).willReturn(Optional.of(existingToken));
+
+        // when
+        refreshTokenService.rotateRefreshToken(userId, refreshToken);
+
+        // then
+        String expectedHashed = AuthService.hashToken(refreshToken);
+        verify(existingToken).updateRefreshToken(eq(expectedHashed), any(LocalDateTime.class));
+    }
+
+    @Test
+    @DisplayName("DB에 존재하지 않으면 새로운 토큰 엔티티를 저장한다")
+    void rotateRefreshToken_SavesNew() {
+        // given
+        UserId userId = new UserId(1L);
+        String refreshToken = "newRefreshTokenString";
+        long expirationMs = 1000000L;
+
+        given(jwtTokenProvider.getRefreshExpirationMs()).willReturn(expirationMs);
+        given(userRefreshTokenRepository.findByUserId(userId)).willReturn(Optional.empty());
+
+        // when
+        refreshTokenService.rotateRefreshToken(userId, refreshToken);
+
+        // then
+        ArgumentCaptor<UserRefreshToken> captor = ArgumentCaptor.forClass(UserRefreshToken.class);
+        verify(userRefreshTokenRepository).save(captor.capture());
+
+        UserRefreshToken savedToken = captor.getValue();
+        String expectedHashed = AuthService.hashToken(refreshToken);
+
+        assertThat(savedToken).isNotNull();
+        assertThat(savedToken.getRefreshToken()).isEqualTo(expectedHashed);
+    }
+}

--- a/src/test/java/com/personal/interview/util/filter/FilterExceptionUtilTest.java
+++ b/src/test/java/com/personal/interview/util/filter/FilterExceptionUtilTest.java
@@ -1,0 +1,68 @@
+package com.personal.interview.util.filter;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.PrintWriter;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+
+import com.personal.interview.global.exception.ErrorCode;
+
+import jakarta.servlet.http.HttpServletResponse;
+import tools.jackson.databind.ObjectMapper;
+
+@ExtendWith(MockitoExtension.class)
+class FilterExceptionUtilTest {
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private PrintWriter printWriter;
+
+    @Test
+    @DisplayName("sendErrorResponse (기본 메시지) - 상태 코드, Content-Type 설정 및 직렬화 호출 확인")
+    void sendErrorResponse_DefaultMessage() throws Exception {
+        // given
+        ErrorCode errorCode = ErrorCode.INVALID_TOKEN;
+        when(response.getWriter()).thenReturn(printWriter);
+
+        // when
+        FilterExceptionUtil.sendErrorResponse(response, errorCode, objectMapper);
+
+        // then
+        verify(response).setStatus(errorCode.getStatus().value());
+        verify(response).setContentType(MediaType.APPLICATION_JSON_VALUE);
+        verify(response).setCharacterEncoding("UTF-8");
+        verify(objectMapper).writeValue(eq(printWriter), any());
+    }
+
+    @Test
+    @DisplayName("sendErrorResponse (커스텀 메시지) - 상태 코드, Content-Type 설정 및 직렬화 호출 확인")
+    void sendErrorResponse_CustomMessage() throws Exception {
+        // given
+        ErrorCode errorCode = ErrorCode.INVALID_CREDENTIALS;
+        String customMessage = "커스텀 에러 메시지입니다.";
+        when(response.getWriter()).thenReturn(printWriter);
+
+        // when
+        FilterExceptionUtil.sendErrorResponse(response, errorCode, customMessage, objectMapper);
+
+        // then
+        verify(response).setStatus(errorCode.getStatus().value());
+        verify(response).setContentType(MediaType.APPLICATION_JSON_VALUE);
+        verify(response).setCharacterEncoding("UTF-8");
+        verify(objectMapper).writeValue(eq(printWriter), any());
+    }
+}

--- a/src/test/java/com/personal/interview/util/validator/SecurityValidatorUtilTest.java
+++ b/src/test/java/com/personal/interview/util/validator/SecurityValidatorUtilTest.java
@@ -1,0 +1,104 @@
+package com.personal.interview.util.validator;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.io.PrintWriter;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+
+import com.personal.interview.global.exception.ErrorCode;
+
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import tools.jackson.databind.ObjectMapper;
+
+@ExtendWith(MockitoExtension.class)
+class SecurityValidatorUtilTest {
+
+    private Validator validator;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    private SecurityValidatorUtil securityValidatorUtil;
+
+    @BeforeEach
+    void setUp() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+        securityValidatorUtil = new SecurityValidatorUtil(validator, objectMapper);
+    }
+
+    static class TestDto {
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        private String email;
+
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        private String password;
+
+        public TestDto(String email, String password) {
+            this.email = email;
+            this.password = password;
+        }
+
+        public String getEmail() {
+            return email;
+        }
+
+        public String getPassword() {
+            return password;
+        }
+    }
+
+    @Test
+    @DisplayName("검증을 통과하면 예외가 발생하지 않는다")
+    void validate_Success() {
+        // given
+        TestDto validDto = new TestDto("test@example.com", "password123");
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        // when & then
+        assertThatCode(() -> securityValidatorUtil.validate(validDto, response))
+                .doesNotThrowAnyException();
+        verifyNoInteractions(response, objectMapper);
+    }
+
+    @Test
+    @DisplayName("실제 DTO 객체에서 값이 누락되어 검증에 실패하면 에러 응답 및 예외가 발생한다")
+    void validate_FailThrowsException() throws Exception {
+        // given
+        TestDto invalidDto = new TestDto("", ""); // 이메일, 비밀번호 모두 Blank
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        PrintWriter printWriter = mock(PrintWriter.class);
+
+        given(response.getWriter()).willReturn(printWriter);
+
+        // when & then
+        assertThatThrownBy(() -> securityValidatorUtil.validate(invalidDto, response))
+                .isInstanceOf(SecurityFilterValidationException.class);
+        // Blank 위반 메시지 중 하나가 나올 것
+
+        verify(response).setStatus(ErrorCode.INVALID_CREDENTIALS.getStatus().value());
+        verify(response).setContentType(MediaType.APPLICATION_JSON_VALUE);
+        verify(response).setCharacterEncoding("UTF-8");
+        verify(objectMapper).writeValue(eq(printWriter), any());
+    }
+}


### PR DESCRIPTION


## 🚀 기능 구현 사항

resolves : #8

### 1. 인증(Authentication) 흐름 구현 및 관련 클래스 작성

사용자 신원 확인을 위한 JWT 기반의 로그인 및 인증 과정을 구현했습니다.
*   **인증 진입점 및 흐름**:
    *   `CustomAuthenticationFilter`: `/api/auth/login` 요청 시 동작하며, 사용자가 제출한 `LoginRequest`에서 아이디와 패스워드를 추출하여 `AuthenticationManager`에 검증을 위임합니다.
    *   `CustomUserDetailsService`: Spring Security가 DB의 사용자 정보를 토대로 검증할 때 호출되며, `UserRepository`에서 회원을 조회해 `SecurityUser` 객체로 반환해 검증을 진행합니다.
*   **성공/실패 핸들러**:

    *   [`JwtAuthenticationSuccessHandler`](cci:2://file:///c:/Spring_Study/web/ai/backend/Personal-Interview/src/main/java/com/personal/interview/global/security/handler/JwtAuthenticationSuccessHandler.java:28:0-62:1): 인증이 성공하면 `JwtTokenProvider`를 사용해 Access Token 및 Refresh Token을 각각 생성하고 응답 본문에 담아 클라이언트에게 반환합니다. 이 때 Refresh Token은 DB에 해싱하여 저장합니다.
    *   `JwtAuthenticationFailureHandler`: 비밀번호 불일치나 사용자 미존재 등 로그인이 실패할 경우, 일관된 JSON 형식의 에러코드(`AUTH_005` 등)를 클라이언트에게 제공합니다.

### 2. 인가(Authorization) 흐름 및 예외 처리 로직 구현

인가 제어, 즉 사용자가 특정 API에 접근할 수 있는지 권한을 확인하는 필터 흐름과 예외 처리 로직을 구현했습니다.
*   **JWT 필터 흐름 (`JwtAuthenticationFilter`)**:
    *   클라이언트가 헤더에 보낸 Access Token을 검사합니다. 토큰이 유효할 경우 `SecurityContextHolder`에 인증 정보([Authentication](cci:1://file:///c:/Spring_Study/web/ai/backend/Personal-Interview/src/test/java/com/personal/interview/global/security/aop/AuthorizeAspectTest.java:55:4-59:5)) 객체를 저장하여 이후 필터와 컨트롤러에서 인증된 사용자로 인식하게 합니다.
*   **전역 예외 처리 및 Security Exception**:
    *   토큰이 존재하지 않거나, 만료, 위변조 된 경우 필터 단에서 바로 예외를 응답 스트림에 쓰지 않고, `FilterExceptionUtil`를 통해 예외를 `request`의 attribute에 담아 둡니다.
    *   이후 `JwtAuthenticationEntryPoint`(AuthenticationException, 401 인증 예외) 및 `JwtAccessDeniedHandler`(AccessDeniedException, 403 인가 예외) 컴포넌트로 요청이 넘어가며, 이 핸들러들에서 공통 응답 포맷으로 깔끔하게 응답을 반환합니다.

### 3. Refresh Token RTR (Refresh Token Rotation) 로직 적용

기존 세션 방식을 탈피하고 보안성이 높은 RTR(Refresh Token Rotation) 기반 재발급을 구현했습니다.
*   **[AuthService](cci:2://file:///c:/Spring_Study/web/ai/backend/Personal-Interview/src/main/java/com/personal/interview/domain/auth/service/AuthService.java:22:0-105:1) 및 [RefreshTokenService](cci:2://file:///c:/Spring_Study/web/ai/backend/Personal-Interview/src/main/java/com/personal/interview/global/security/service/RefreshTokenService.java:15:0-36:1) 로직**:
    *   **토큰 해싱 관리**: 사용자가 로그인 시 발급받은 Refresh Token은 그 자체를 DB([UserRefreshToken](cci:2://file:///c:/Spring_Study/web/ai/backend/Personal-Interview/src/main/java/com/personal/interview/domain/auth/entity/UserRefreshToken.java:20:0-63:1) 엔티티)에 저장하지 않고 생성 시 즉각 SHA-256 방식으로 **해싱하여 DB에 저장**합니다. 이 과정을 통해 DB가 털리더라도 원본 Refresh Token이 노출되지 않습니다.
    *   **RTR (토큰 회전) 로직**: `/api/auth/refresh` API 요청 시 사용자가 제출한 Refresh Token 값을 암호화하여 DB의 값과 비교합니다.
        유효성 검증을 통과하면 새로운 Access Token과 *새로운 Refresh Token*을 발급합니다.
    *   **비정상적인 재사용 감지**: 이미 만료되거나 이미 사용된(RTR로 교체된) Refresh Token으로 재발급을 요청할 경우 탈취된 토큰의 재사용으로 판단하고, 즉시 **해당 사용자의 모든 Refresh Token 세션 정보를 DB에서 삭제**하며 강제 로그아웃 시킵니다.

### 4. 커스텀 인가 로직 (`@Authorize` 및 유틸리티)

Spring Security 기본 `@PreAuthorize` 대신 가독성과 확장성이 높은 도메인 커스텀 어노테이션 기반 AOP 인가를 구현했습니다.
*   **`@Authorize` 어노테이션 추가**: 컨트롤러 메서드에 `@Authorize(UserRole.ROLE_DRAFT)` 등 도메인 객체(`UserRole`)를 활용한 직접적이고 명시적인 권한 설정을 가능하게 합니다. Spring의 SPEL 문법에 의존하지 않아 컴파일 타임에 타입 안전성을 보장받습니다.
*   **[AuthorizeAspect](cci:2://file:///c:/Spring_Study/web/ai/backend/Personal-Interview/src/main/java/com/personal/interview/global/security/aop/AuthorizeAspect.java:19:0-48:1) (AOP 기반 처리)**: 위 어노테이션이 붙은 메서드가 실행되기 즉시 가로채어(AOP) `SecurityContextHolder`의 권한을 확인합니다. 권한이 없거나 부족하면 즉시 [DomainException(ACCESS_DENIED)](cci:1://file:///c:/Spring_Study/web/ai/backend/Personal-Interview/src/main/java/com/personal/interview/global/exception/GlobalExceptionHandler.java:24:4-36:5) 예외를 발생시킵니다.
*   **관련 Util 추가**: `SecurityValidatorUtil`(이메일/패스워드 입력값 검증 유틸) 및 `FilterExceptionUtil`(필터단에서 발생하는 예외 정보를 컨트롤러단 예외 핸들링 구조와 호환되게 넘기기 위한 유틸)이 추가되었습니다.

---

## 🧾 review point

*   **관련 개발 컨트롤러/서비스 유닛 및 통합 테스트 코드검증 완료**
*  인증 인가 관련 filter 와 handler 클래스들의 예외 케이스를 잘 설계하고 개발했는데 이상있는 점 있으면 피드백 부탁드립니다
*   **RTR 해싱 처리 보안성 강화**: 단순히 토큰을 발급/갱신하는 것에서 나아가, 데이터베이스가 탈취 당하는 상황에서도 안전하도록 해싱 처리를 시도했습니다.
*   **Custom AOP 인가 처리**: `@PreAuthorize("hasRole('USER')")` 문자열 검증 방식이 주는 제약을 타파하고자 `@Authorize` 커스텀 애노테이션과 도메인 `UserRole` Enum을 조합한 형태를 선택했습니다. 이 방식에 대한 구조 설계 피드백이 궁금합니다.
